### PR TITLE
fix freeshot extractor

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: realbestia1/easyproxy
+  IMAGE_NAME: letruxux/easyproxy
 
 jobs:
   build-and-push:

--- a/extractors/freeshot.py
+++ b/extractors/freeshot.py
@@ -145,6 +145,7 @@ class FreeshotExtractor:
         
         # Token extraction (no need for try-except wrapper since ExtractorError propagates)
         # Nuova estrazione token via currentToken
+        body["html"] if isinstance(body, dict) and body.get("html") else body
         match = re.search(r'streamUrl\s*:\s*"([^"]+)"', body)
         if not match:
             # Fallback al vecchio metodo iframe


### PR DESCRIPTION
risolve questo bug

```
2026-04-25 14:17:32,146 - CRITICAL - ❌ Critical error with FreeshotExtractor: expected string or bytes-like object, got 'dict'
2026-04-25 14:17:32,146 - ERROR - Error in proxy request: expected string or bytes-like object, got 'dict'
```

per qualche motivo, spesso body è `{"html":"..."}` invece della stringa diretta