### PR TITLE
Recover Mediaset playback within WARP

### DIFF
--- a/extractors/mediaset.py
+++ b/extractors/mediaset.py
@@ -1,5 +1,7 @@
+import asyncio
 import html
 import json
+import logging
 import re
 import urllib.parse
 import uuid
@@ -7,9 +9,17 @@ import xml.etree.ElementTree as ET
 from urllib.parse import urlparse
 
 import aiohttp
+import config as _config
+from config import (
+    ALL_PROXY_ERRORS,
+    SELECTED_PROXY_CONTEXT,
+    STRICT_PROXY_CONTEXT,
+)
 from extractors.base import BaseExtractor, ExtractorError
 from extractors.widevine import extract_widevine_pssh, resolve_widevine_device
 
+
+logger = logging.getLogger(__name__)
 
 WITTY_ORIGIN = "https://www.wittytv.it"
 MEDIASET_ORIGIN = "https://mediasetinfinity.mediaset.it"
@@ -144,7 +154,45 @@ class MediasetExtractor(BaseExtractor):
         try:
             resolved = await self._resolve_playback(url)
         except Exception as error:
-            raise ExtractorError(f"Mediaset extraction failed: {error}") from error
+            network_errors = ALL_PROXY_ERRORS + (
+                asyncio.TimeoutError,
+                aiohttp.ClientConnectionError,
+                aiohttp.ServerDisconnectedError,
+            )
+            can_retry_warp = (
+                isinstance(error, network_errors)
+                and self._session_proxy == _config.WARP_PROXY_URL
+            )
+            if not can_retry_warp:
+                detail = str(error) or type(error).__name__
+                raise ExtractorError(
+                    f"Mediaset extraction failed: {detail}"
+                ) from error
+
+            logger.warning(
+                "Mediaset extraction via WARP failed with %r; "
+                "retrying through a fresh WARP session",
+                error,
+            )
+            if self.session and not self.session.closed:
+                await self.session.close()
+            self.session = None
+            self._session_proxy = None
+
+            selected_proxy_token = SELECTED_PROXY_CONTEXT.set(
+                _config.WARP_PROXY_URL
+            )
+            strict_proxy_token = STRICT_PROXY_CONTEXT.set(True)
+            try:
+                resolved = await self._resolve_playback(url)
+            except Exception as retry_error:
+                detail = str(retry_error) or type(retry_error).__name__
+                raise ExtractorError(
+                    f"Mediaset extraction failed after WARP retry: {detail}"
+                ) from retry_error
+            finally:
+                STRICT_PROXY_CONTEXT.reset(strict_proxy_token)
+                SELECTED_PROXY_CONTEXT.reset(selected_proxy_token)
 
         clearkey = ",".join(
             f"{kid}:{key}" for kid, key in resolved["keys"].items()

--- a/services/proxy_core.py
+++ b/services/proxy_core.py
@@ -643,6 +643,20 @@ class HLSProxyCoreMixin:
         session = await self._get_session(prefer_default_family=prefer_default_family)
         return session, None
 
+    async def _invalidate_proxy_session(self, proxy_url: str | None) -> bool:
+        """Drop one pooled proxy session so the next request gets a new connector."""
+        if not proxy_url or not hasattr(self, "_proxy_sessions"):
+            return False
+        session = self._proxy_sessions.pop(proxy_url, None)
+        if hasattr(self, "_proxy_session_atimes"):
+            self._proxy_session_atimes.pop(proxy_url, None)
+        if not session:
+            return False
+        if not session.closed:
+            await session.close()
+        logger.warning("[NET] Invalidated pooled proxy session: %s", proxy_url)
+        return True
+
     async def _retry_special_cdn_request(self, request_target, headers, disable_ssl: bool):
         """Retry a provider-protected CDN once via an alternate aiohttp route."""
         _ENABLE_WARP = _shared.ENABLE_WARP

--- a/services/proxy_streaming.py
+++ b/services/proxy_streaming.py
@@ -1379,54 +1379,105 @@ class HLSProxyStreamingMixin:
 
             try:
                 # Parallel download of init and media segment
-                async def fetch_init():
-                    if not init_url:
-                        return b""
-                    disable_ssl = get_ssl_setting_for_url(init_url)
+                network_errors = ALL_PROXY_ERRORS + (
+                    ClientConnectionError,
+                    ServerDisconnectedError,
+                    asyncio.TimeoutError,
+                    OSError,
+                )
+
+                async def fetch_part(session, part_url, timeout, label):
+                    if not part_url:
+                        return b"", False
+                    disable_ssl = get_ssl_setting_for_url(part_url)
                     try:
-                        async with segment_session.get(
-                            init_url,
+                        async with session.get(
+                            part_url,
                             headers=headers,
                             ssl=not disable_ssl,
-                            timeout=aiohttp.ClientTimeout(total=10),
+                            timeout=aiohttp.ClientTimeout(total=timeout),
                         ) as resp:
                             if resp.status == 200:
                                 content = await resp.read()
                                 if content:
-                                    return content
+                                    return content, False
                             logger.error(
-                                f"❌ Init segment returned status {resp.status}: {init_url}"
+                                "❌ %s returned status %s: %s",
+                                label,
+                                resp.status,
+                                part_url,
                             )
-                            return None
-                    except Exception as e:
-                        logger.error(f"❌ Failed to fetch init segment: {e}")
-                        return None
-
-                async def fetch_segment():
-                    if not url:
-                        return b""
-                    disable_ssl = get_ssl_setting_for_url(url)
-                    try:
-                        async with segment_session.get(
-                            url,
-                            headers=headers,
-                            ssl=not disable_ssl,
-                            timeout=aiohttp.ClientTimeout(total=15),
-                        ) as resp:
-                            if resp.status == 200:
-                                return await resp.read()
-                            logger.error(
-                                f"❌ Segment returned status {resp.status}: {url}"
-                            )
-                            return None
-                    except Exception as e:
-                        logger.error(f"❌ Failed to fetch segment: {e}")
-                        return None
+                            return None, False
+                    except network_errors as error:
+                        logger.error("❌ Failed to fetch %s: %r", label, error)
+                        return None, True
+                    except Exception as error:
+                        logger.error("❌ Failed to fetch %s: %r", label, error)
+                        return None, False
 
                 # Parallel fetch
-                init_content, segment_content = await asyncio.gather(
-                    fetch_init(), fetch_segment()
+                init_result, segment_result = await asyncio.gather(
+                    fetch_part(segment_session, init_url, 10, "init segment"),
+                    fetch_part(segment_session, url, 15, "segment"),
                 )
+                init_content, init_retryable = init_result
+                segment_content, segment_retryable = segment_result
+
+                # The WARP keepalive uses a separate session, so it can be
+                # healthy while this long-lived pooled connector is stale.
+                # Recreate that connector and remain on WARP for the retry.
+                can_retry_warp = (
+                    segment_proxy
+                    and segment_proxy == _shared.WARP_PROXY_URL
+                    and (init_retryable or segment_retryable)
+                )
+                if can_retry_warp:
+                    await self._invalidate_proxy_session(segment_proxy)
+                    if not await self.is_warp_healthy(timeout_sec=3):
+                        logger.warning(
+                            "WARP health probe failed; reconnecting before segment retry"
+                        )
+                        await self.reconnect_warp()
+                        await self._invalidate_proxy_session(segment_proxy)
+
+                    retry_session, retry_proxy = await self._get_proxy_session(
+                        url or init_url,
+                        bypass_warp=False,
+                        forced_proxy=segment_proxy,
+                    )
+                    try:
+                        retry_init, retry_segment = await asyncio.gather(
+                            fetch_part(
+                                retry_session,
+                                init_url if init_retryable else None,
+                                10,
+                                "init segment (WARP retry)",
+                            ),
+                            fetch_part(
+                                retry_session,
+                                url if segment_retryable else None,
+                                15,
+                                "segment (WARP retry)",
+                            ),
+                        )
+                    finally:
+                        if (
+                            retry_session
+                            and retry_proxy
+                            and not retry_session.closed
+                        ):
+                            await retry_session.close()
+                    if init_retryable and retry_init[0] is not None:
+                        init_content = retry_init[0]
+                    if segment_retryable and retry_segment[0] is not None:
+                        segment_content = retry_segment[0]
+                    if (
+                        (not init_retryable or init_content is not None)
+                        and (not segment_retryable or segment_content is not None)
+                    ):
+                        logger.warning(
+                            "Recovered ClearKey segment request through a fresh WARP session"
+                        )
             finally:
                 if segment_session and segment_proxy and not segment_session.closed:
                     await segment_session.close()


### PR DESCRIPTION
## What changed

- Retry Mediaset and WittyTV extraction through a fresh WARP session after a WARP network timeout.
- Invalidate a stalled pooled WARP connector before retrying ClearKey init and media segments.
- Probe WARP health and reconnect WARP when the tunnel is unhealthy, then retry through WARP.
- Log empty timeout exceptions with their concrete exception type.

## Why

EasyProxy intentionally kept the pooled WARP session alive indefinitely, while its keepalive checked tunnel health with a separate fresh session. The health probe could therefore succeed even when the long-lived connector used by playback was stalled after hours of use.

## Routing contract

Recovery never falls back to the server's direct connection. A request that was using WARP remains on WARP for extraction, health recovery, and segment retry. Other configured proxies are left unchanged.

## Impact

Long Mediaset and WittyTV playback can recover from a stale WARP connection pool without changing the selected route. If the WARP tunnel itself is unhealthy, EasyProxy runs its existing WARP reconnection flow before retrying.

## Validation

- Full live WittyTV extraction returned the DASH manifest and ClearKey data
- Stale WARP pool was invalidated and retried through a fresh WARP session
- Failed WARP health probe triggered WARP reconnection before the WARP retry
- Explicit WARP routing remained on WARP
- Non-WARP proxies were not rerouted or retried by this recovery
- PL053 and other non-network errors were not retried
- Tests asserted that no direct session was invoked
- Python compilation and git diff checks passed
- Temporary test environment removed; no test artifacts added