### PR TITLE
fix(termux): support proot-distro 5 and resilient updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+/.venv/
 extractors/.dlhd_cache
 flaresolverr/
 byparr/

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The easiest way to get EasyProxy plus solvers on Windows:
 #### 📱 Termux (Android)
 EasyProxy plus solvers is fully supported on Android via Termux + Ubuntu proot.
 
+The setup supports proot-distro 5 and earlier releases, and installs Python dependencies in an isolated virtual environment at `/root/EasyProxy/.venv`.
+
 Android users can also install the APK build if they prefer a simpler app-style setup. The APK is convenient, but it is not as complete as the Python/Termux version, so Termux remains the recommended option for full functionality.
 
 For Termux, full functionality requires a 64-bit Android device. On 32-bit devices, some components and solvers may not work.
@@ -63,7 +65,7 @@ For Termux, full functionality requires a 64-bit Android device. On 32-bit devic
 1.  **Install Termux** from [F-Droid](https://f-droid.org/en/packages/com.termux/) (do NOT use Play Store version).
 2.  **Run the One-Shot Setup**:
     ```bash
-    curl -sL "https://raw.githubusercontent.com/realbestia1/EasyProxy/main/termux_setup.sh?$(date +%s)" | bash
+    curl -fsSL --retry 3 "https://raw.githubusercontent.com/realbestia1/EasyProxy/main/termux_setup.sh?$(date +%s)" | bash
     ```
 3.  **Prevent Termux from Sleeping**:
     - **Wake Lock**: Swipe down your notification bar and click **"Acquire wake-lock"** on the Termux notification.
@@ -72,6 +74,7 @@ For Termux, full functionality requires a 64-bit Android device. On 32-bit devic
     - `easyproxy`: Start the full stack.
     - `easyproxy-update`: Update code and dependencies.
     - `easyproxy-stop`: Stop all services.
+    - `easyproxy-logs`: Attach to the running session or show the saved logs.
 
 *Access the dashboard at `http://localhost:7860`*
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ For Termux, full functionality requires a 64-bit Android device. On 32-bit devic
     - `easyproxy-stop`: Stop all services.
     - `easyproxy-logs`: Attach to the running session or show the saved logs.
 
+If `easyproxy-update` reports `CANNOT LINK EXECUTABLE "curl"`, repair the
+partially upgraded Termux packages first, then retry the update:
+
+```bash
+apt update && apt full-upgrade -y
+easyproxy-update
+```
+
 *Access the dashboard at `http://localhost:7860`*
 
 ---

--- a/termux_setup.sh
+++ b/termux_setup.sh
@@ -3,7 +3,7 @@
 # EasyProxy Full - Termux One-Shot Setup (No WARP)
 # ============================================================
 # Usage: Open Termux, then run:
-#   curl -sL https://raw.githubusercontent.com/realbestia1/EasyProxy/main/termux_setup.sh | bash
+#   curl -fsSL --retry 3 https://raw.githubusercontent.com/realbestia1/EasyProxy/main/termux_setup.sh | bash
 #
 # Or copy this file and run:
 #   chmod +x termux_setup.sh && ./termux_setup.sh
@@ -12,7 +12,7 @@
 #   easyproxy
 # ============================================================
 
-set -e
+set -Eeuo pipefail
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -25,7 +25,10 @@ warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 err()  { echo -e "${RED}[ERR]${NC} $1"; exit 1; }
 info() { echo -e "${BLUE}[INFO]${NC} $1"; }
 
+trap 'err "Setup failed at line $LINENO: $BASH_COMMAND"' ERR
+
 DISTRO_NAME="ubuntu"
+DISTRO_IMAGE="ubuntu"
 EP_DIR="/root/EasyProxy"
 EP_REPO="https://github.com/realbestia1/EasyProxy.git"
 
@@ -39,16 +42,29 @@ echo ""
 info "Phase 1/5: Installing Termux packages..."
 termux-setup-storage 2>/dev/null || true
 pkg update -y
-pkg install -y proot-distro git pulseaudio wget screen
+pkg install -y proot-distro git curl pulseaudio wget screen
 log "Termux packages installed."
 
 info "Phase 2/5: Setting up Ubuntu environment..."
-proot-distro install "$DISTRO_NAME" 2>/dev/null && log "Ubuntu installed." || warn "Ubuntu already installed, continuing..."
+PROOT_DISTRO_VERSION="$(proot-distro --version 2>/dev/null || true)"
+if [[ "$PROOT_DISTRO_VERSION" =~ ([0-9]+)(\.|$) ]] && (( BASH_REMATCH[1] >= 5 )); then
+    DISTRO_IMAGE="ubuntu:24.04"
+fi
 
-info "Phase 3/4: Configuring Ubuntu and installing EasyProxy..."
-proot-distro login "$DISTRO_NAME" -- bash -c '
+if proot-distro login "$DISTRO_NAME" -- true >/dev/null 2>&1; then
+    warn "Ubuntu is already installed, continuing..."
+else
+    info "Installing $DISTRO_IMAGE..."
+    proot-distro install "$DISTRO_IMAGE"
+    proot-distro login "$DISTRO_NAME" -- true
+    log "Ubuntu installed."
+fi
+
+info "Phase 3/5: Configuring Ubuntu and installing EasyProxy..."
+proot-distro login "$DISTRO_NAME" -- bash -s <<'UBUNTU_SETUP'
+    set -Eeuo pipefail
+    trap 'echo "[FATAL] Ubuntu setup failed at line $LINENO: $BASH_COMMAND" >&2' ERR
     export DEBIAN_FRONTEND=noninteractive
-    export PIP_BREAK_SYSTEM_PACKAGES=1
 
     echo "[INFO] Inside Ubuntu: Checking disk space..."
     df -h /
@@ -58,69 +74,75 @@ proot-distro login "$DISTRO_NAME" -- bash -c '
     sed -i "s|security.ubuntu.com|mirrors.kernel.org|g" /etc/apt/sources.list || true
 
     echo "[INFO] Inside Ubuntu: Adding non-snap Chromium PPA..."
-    apt-get install -y software-properties-common || true
-    add-apt-repository -y ppa:xtradeb/apps || true
+    apt-get update -y
+    apt-get install -y software-properties-common
+    add-apt-repository -y ppa:xtradeb/apps
 
     echo "[INFO] Inside Ubuntu: Updating packages..."
     apt-get update -y
 
-    echo "[INFO] Inside Ubuntu: Installing Python, browser, Node.js and runtime packages..."
-    apt-get install -y --fix-missing \
-        python3 python3-venv python3.13-venv python-is-python3 python3-pip git curl wget \
-        libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 libxkbcommon0 libxcomposite1 \
-        libxdamage1 libxfixes3 libxrandr2 libgbm1 libasound2t64 libpango-1.0-0 libcairo2 \
-        libatspi2.0-0 fonts-liberation ca-certificates chromium chromium-driver procps \
-        libxshmfence1 libglu1-mesa libx11-xcb1 libxcb-dri3-0 libxss1 libxtst6 libxslt1.1 || true
-
-    if ! command -v pip >/dev/null 2>&1 && ! python3 -m pip --version >/dev/null 2>&1; then
-        echo "[INFO] Inside Ubuntu: Apt pip missing, installing manually..."
-        curl -sS https://bootstrap.pypa.io/get-pip.py | python3 - --break-system-packages || true
+    ASOUND_PACKAGE="libasound2"
+    if apt-cache show libasound2t64 >/dev/null 2>&1; then
+        ASOUND_PACKAGE="libasound2t64"
     fi
+
+    echo "[INFO] Inside Ubuntu: Installing Python, browser and runtime packages..."
+    apt-get install -y --fix-missing \
+        python3 python3-venv python-is-python3 python3-pip git curl wget \
+        libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 libxkbcommon0 libxcomposite1 \
+        libxdamage1 libxfixes3 libxrandr2 libgbm1 "$ASOUND_PACKAGE" libpango-1.0-0 libcairo2 \
+        libatspi2.0-0 fonts-liberation ca-certificates chromium chromium-driver procps \
+        libxshmfence1 libglu1-mesa libx11-xcb1 libxcb-dri3-0 libxss1 libxtst6 libxslt1.1
+
+    command -v chromium >/dev/null 2>&1
+    command -v chromedriver >/dev/null 2>&1
 
     EP_DIR="/root/EasyProxy"
     EP_REPO="https://github.com/realbestia1/EasyProxy.git"
 
     if [ -d "$EP_DIR/.git" ]; then
         echo "[WARN] EasyProxy already exists, pulling latest..."
-        cd "$EP_DIR" && git pull || true
-    elif [ -d "$EP_DIR" ]; then
-        echo "[WARN] EasyProxy directory exists without .git, reusing it."
+        git -C "$EP_DIR" pull --ff-only
+    elif [ -e "$EP_DIR" ]; then
+        echo "[FATAL] $EP_DIR exists but is not a Git checkout." >&2
+        exit 1
     else
         echo "[INFO] Cloning EasyProxy..."
         git clone "$EP_REPO" "$EP_DIR"
     fi
 
-    echo "[INFO] Setting up python pip config..."
-    mkdir -p ~/.config/pip
-    {
-        echo "[global]"
-        echo "break-system-packages = true"
-    } > ~/.config/pip/pip.conf
+    VENV_DIR="$EP_DIR/.venv"
+    echo "[INFO] Creating the EasyProxy Python virtual environment..."
+    python3 -m venv "$VENV_DIR"
+    VENV_PYTHON="$VENV_DIR/bin/python"
 
-    echo "[INFO] Upgrading pip..."
-    python3 -m pip install --upgrade pip setuptools wheel --break-system-packages || true
+    echo "[INFO] Upgrading pip in the virtual environment..."
+    "$VENV_PYTHON" -m pip install --upgrade pip setuptools wheel
 
     echo "[INFO] Installing EasyProxy requirements..."
     cd "$EP_DIR"
-    python3 -m pip install --no-cache-dir --ignore-installed -r requirements.txt --break-system-packages || true
+    "$VENV_PYTHON" -m pip install --no-cache-dir -r requirements.txt
 
     echo "[INFO] Playwright will use system Chromium (/usr/bin/chromium)..."
     # No need to install playwright chromium, saves ~500MB
 
     echo "[INFO] Setting up FlareSolverr..."
     if [ ! -d "$EP_DIR/flaresolverr/.git" ]; then
-        rm -rf "$EP_DIR/flaresolverr" 2>/dev/null || true
+        if [ -e "$EP_DIR/flaresolverr" ]; then
+            echo "[FATAL] $EP_DIR/flaresolverr exists but is not a Git checkout." >&2
+            exit 1
+        fi
         git clone https://github.com/FlareSolverr/FlareSolverr.git "$EP_DIR/flaresolverr"
     fi
     cd "$EP_DIR/flaresolverr"
     git checkout -- src/utils.py 2>/dev/null || true
-    sed -i "s|options.add_argument('\''--no-sandbox'\'')|options.add_argument('\''--no-sandbox'\''); options.add_argument('\''--disable-dev-shm-usage'\''); options.add_argument('\''--disable-gpu'\''); options.add_argument('\''--headless=new'\'')|" src/utils.py 2>/dev/null || true
+    sed -i "s|options.add_argument('--no-sandbox')|options.add_argument('--no-sandbox'); options.add_argument('--disable-dev-shm-usage'); options.add_argument('--disable-gpu'); options.add_argument('--headless=new')|" src/utils.py
     sed -i "s|^\([[:space:]]*\)start_xvfb_display()|\1pass|g" src/utils.py 2>/dev/null || true
     sed -i "s|driver_executable_path=driver_exe_path|driver_executable_path=\"/usr/bin/chromedriver\"|" src/utils.py 2>/dev/null || true
-    python3 -m pip install --no-cache-dir --ignore-installed -r requirements.txt --break-system-packages || true
+    "$VENV_PYTHON" -m pip install --no-cache-dir -r requirements.txt
 
     echo "[INFO] Installing critical dependencies..."
-    python3 -m pip install --no-cache-dir --ignore-installed uvicorn prometheus-client certifi --break-system-packages || true
+    "$VENV_PYTHON" -m pip install --no-cache-dir uvicorn prometheus-client certifi
 
     if [ ! -f "$EP_DIR/.env" ]; then
         {
@@ -128,31 +150,49 @@ proot-distro login "$DISTRO_NAME" -- bash -c '
             echo "ENABLE_WARP=false"
         } > "$EP_DIR/.env"
     fi
-'
+UBUNTU_SETUP
 log "Ubuntu environment and EasyProxy installation complete."
 
-info "Phase 5/5: Creating launcher scripts..."
-PROOT_ROOTFS="$PREFIX/var/lib/proot-distro/installed-rootfs/ubuntu/root"
-
-cat > "$PROOT_ROOTFS/easyproxy_start.sh" << 'LAUNCHER_EOF'
+info "Phase 4/5: Creating the Ubuntu launcher..."
+proot-distro login "$DISTRO_NAME" -- bash -c '
+    set -Eeuo pipefail
+    target=/root/easyproxy_start.sh
+    temporary="${target}.tmp.$$"
+    trap '\''rm -f "$temporary"'\'' EXIT
+    cat > "$temporary"
+    chmod 0755 "$temporary"
+    mv -f "$temporary" "$target"
+    trap - EXIT
+' <<'LAUNCHER_EOF'
 #!/bin/bash
-set -u
-export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
-export PIP_BREAK_SYSTEM_PACKAGES=1
-export PORT=7860
-export ENABLE_WARP=false
+set -Eeuo pipefail
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH:-}"
 LOG_DIR="/root/.easyproxy"
 LOG_FILE="$LOG_DIR/easyproxy.log"
+PID_FILE="$LOG_DIR/easyproxy.pid"
+EP_DIR="/root/EasyProxy"
+VENV_PYTHON="$EP_DIR/.venv/bin/python"
+APP_PID=""
 
 mkdir -p "$LOG_DIR"
 touch "$LOG_FILE"
 exec >>"$LOG_FILE" 2>&1
 
 cleanup() {
-    kill "${FLARE_PID:-}" 2>/dev/null || true
+    status=$?
+    trap - EXIT INT TERM HUP
+    if [ -n "$APP_PID" ] && kill -0 "$APP_PID" 2>/dev/null; then
+        kill "$APP_PID" 2>/dev/null || true
+        wait "$APP_PID" 2>/dev/null || true
+    fi
+    rm -f "$PID_FILE"
+    exit "$status"
 }
 
 trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
 
 echo ""
 echo "=================================================="
@@ -168,27 +208,46 @@ fi
 export CHROME_EXE_PATH="${CHROME_BIN:-}"
 export CHROME_DRIVER_PATH="/usr/bin/chromedriver"
 export FLARESOLVERR_URL=http://localhost:8191
-if [ ! -d /root/EasyProxy ]; then
-    echo "[FATAL] /root/EasyProxy not found inside Ubuntu."
+export ENABLE_WARP="${ENABLE_WARP:-false}"
+
+if [ ! -d "$EP_DIR" ]; then
+    echo "[FATAL] $EP_DIR not found inside Ubuntu."
+    exit 1
+fi
+if [ ! -x "$VENV_PYTHON" ]; then
+    echo "[FATAL] Python virtual environment not found at $EP_DIR/.venv."
     exit 1
 fi
 
-cd /root/EasyProxy
+cd "$EP_DIR"
 
 if [ -f .env ]; then
-    export $(grep -v "^#" .env | xargs) 2>/dev/null || true
+    set -a
+    # shellcheck disable=SC1091
+    . ./.env
+    set +a
 fi
 
 PORT=${PORT:-7860}
+if ! [[ "$PORT" =~ ^[0-9]+$ ]] || (( PORT < 1 || PORT > 65535 )); then
+    echo "[FATAL] Invalid PORT value: $PORT"
+    exit 1
+fi
 
-pkill -9 -f "python3.*(app|flaresolverr|easyproxy_start)" 2>/dev/null || true
-pkill -9 -f "node.*flaresolverr" 2>/dev/null || true
+if [ -r "$PID_FILE" ]; then
+    OLD_PID="$(cat "$PID_FILE")"
+    if [[ "$OLD_PID" =~ ^[0-9]+$ ]] && kill -0 "$OLD_PID" 2>/dev/null; then
+        echo "[FATAL] EasyProxy is already running with PID $OLD_PID."
+        exit 1
+    fi
+    rm -f "$PID_FILE"
+fi
 
 echo ""
 echo "EasyProxy Full - Termux Edition"
 echo "Port: $PORT | Mode: Headless"
-echo "Python: $(python3 --version 2>/dev/null || echo missing)"
-echo "Pip: $(python3 -m pip --version 2>/dev/null || echo missing)"
+echo "Python: $("$VENV_PYTHON" --version 2>/dev/null || echo missing)"
+echo "Pip: $("$VENV_PYTHON" -m pip --version 2>/dev/null || echo missing)"
 echo "Chromium: ${CHROME_BIN:-missing}"
 echo "Chromedriver: $(command -v chromedriver 2>/dev/null || echo missing)"
 echo ""
@@ -196,22 +255,28 @@ echo ""
 echo "FlareSolverr starts on-demand via Python code"
 
 echo "Starting EasyProxy on port $PORT..."
-cd /root/EasyProxy
-python3 -c "from app import app; from aiohttp import web; web.run_app(app, host='0.0.0.0', port=$PORT)"
+"$VENV_PYTHON" app.py &
+APP_PID=$!
+echo "$APP_PID" > "$PID_FILE"
+wait "$APP_PID"
 LAUNCHER_EOF
-chmod +x "$PROOT_ROOTFS/easyproxy_start.sh"
+log "Ubuntu launcher created through proot-distro login."
 
-mkdir -p "$HOME/../usr/bin"
+info "Phase 5/5: Creating Termux launcher scripts..."
+mkdir -p "$PREFIX/bin"
 cat > "$PREFIX/bin/easyproxy" << 'CMD_EOF'
 #!/data/data/com.termux/files/usr/bin/bash
+set -Eeuo pipefail
 LOG_DIR="$HOME/.easyproxy"
 TERMUX_LOG="$LOG_DIR/screen.log"
 
 mkdir -p "$LOG_DIR"
 
-LOCAL_IP=$(ip route get 1.1.1.1 2>/dev/null | awk "{print \$7}")
-[ -z "$LOCAL_IP" ] && LOCAL_IP=$(ifconfig wlan0 2>/dev/null | grep "inet " | awk "{print \$2}")
-[ -z "$LOCAL_IP" ] && LOCAL_IP="localhost"
+LOCAL_IP="$(ip route get 1.1.1.1 2>/dev/null | awk '{print $7; exit}' || true)"
+if [ -z "$LOCAL_IP" ]; then
+    LOCAL_IP="$(ifconfig wlan0 2>/dev/null | awk '/inet / {print $2; exit}' || true)"
+fi
+LOCAL_IP="${LOCAL_IP:-localhost}"
 
 if screen -list | grep -q "[.]easyproxy[[:space:]]"; then
     echo "EasyProxy is already running."
@@ -227,7 +292,8 @@ echo "   To view logs:     easyproxy-logs"
 echo "   To stop:          easyproxy-stop"
 echo ""
 
-screen -L -Logfile "$TERMUX_LOG" -dmS easyproxy bash -lc "proot-distro login ubuntu -- bash /root/easyproxy_start.sh"
+screen -L -Logfile "$TERMUX_LOG" -dmS easyproxy \
+    bash -lc 'exec proot-distro login ubuntu -- /root/easyproxy_start.sh'
 sleep 3
 
 if ! screen -list | grep -q "[.]easyproxy[[:space:]]"; then
@@ -246,9 +312,11 @@ chmod +x "$PREFIX/bin/easyproxy"
 
 cat > "$PREFIX/bin/easyproxy-update" << 'UPD_EOF'
 #!/data/data/com.termux/files/usr/bin/bash
+set -Eeuo pipefail
 echo "Running full EasyProxy system update..."
 easyproxy-stop 2>/dev/null || true
-curl -sL "https://raw.githubusercontent.com/realbestia1/EasyProxy/main/termux_setup.sh?$(date +%s)" | bash
+curl -fsSL --retry 3 --connect-timeout 20 \
+    "https://raw.githubusercontent.com/realbestia1/EasyProxy/main/termux_setup.sh?$(date +%s)" | bash
 echo "EasyProxy system updated successfully!"
 easyproxy
 UPD_EOF
@@ -256,16 +324,56 @@ chmod +x "$PREFIX/bin/easyproxy-update"
 
 cat > "$PREFIX/bin/easyproxy-stop" << 'STOP_EOF'
 #!/data/data/com.termux/files/usr/bin/bash
+set -u
 echo "Stopping EasyProxy and all solvers..."
-proot-distro login ubuntu -- bash -c 'pkill -9 -f "python3.*(app|flaresolverr|easyproxy_start)"; pkill -9 -f "gunicorn"; pkill -9 Xvfb' 2>/dev/null
+STOP_STATUS=0
+if ! proot-distro login ubuntu -- bash -s <<'GUEST_STOP'; then
+PID_FILE="/root/.easyproxy/easyproxy.pid"
+
+if [ -r "$PID_FILE" ]; then
+    APP_PID="$(cat "$PID_FILE")"
+    if [[ "$APP_PID" =~ ^[0-9]+$ ]] && kill -0 "$APP_PID" 2>/dev/null; then
+        kill "$APP_PID" 2>/dev/null || true
+        for _ in {1..20}; do
+            kill -0 "$APP_PID" 2>/dev/null || break
+            sleep 0.25
+        done
+        kill -KILL "$APP_PID" 2>/dev/null || true
+    fi
+    rm -f "$PID_FILE"
+fi
+
+# Compatibility cleanup for processes started by older EasyProxy launchers.
+pkill -TERM -f 'python3.*(app|flaresolverr|easyproxy_start)' 2>/dev/null || true
+pkill -TERM -f 'node.*flaresolverr' 2>/dev/null || true
+pkill -TERM -f gunicorn 2>/dev/null || true
+pkill -TERM Xvfb 2>/dev/null || true
+GUEST_STOP
+    echo "Warning: could not stop guest processes through proot-distro login." >&2
+    STOP_STATUS=1
+fi
+
 screen -X -S easyproxy quit 2>/dev/null || true
-pkill -9 -f "proot-distro.*ubuntu" 2>/dev/null || true
+for _ in {1..10}; do
+    screen -list | grep -q "[.]easyproxy[[:space:]]" || break
+    sleep 0.2
+done
+
+if screen -list | grep -q "[.]easyproxy[[:space:]]"; then
+    echo "Failed to stop the EasyProxy screen session." >&2
+    exit 1
+fi
+
+if [ "$STOP_STATUS" -ne 0 ]; then
+    exit "$STOP_STATUS"
+fi
 echo "Stopped."
 STOP_EOF
 chmod +x "$PREFIX/bin/easyproxy-stop"
 
 cat > "$PREFIX/bin/easyproxy-logs" << 'LOGS_EOF'
 #!/data/data/com.termux/files/usr/bin/bash
+set -u
 LOG_DIR="$HOME/.easyproxy"
 echo "Opening logs... (Press Ctrl+A then D to exit logs without stopping)"
 if screen -list | grep -q "[.]easyproxy[[:space:]]"; then

--- a/termux_setup.sh
+++ b/termux_setup.sh
@@ -41,7 +41,11 @@ echo ""
 
 info "Phase 1/5: Installing Termux packages..."
 termux-setup-storage 2>/dev/null || true
-pkg update -y
+# Termux is rolling-release and does not support partial upgrades.  Keep the
+# complete native environment aligned before installing individual packages;
+# otherwise curl and its OpenSSL/ngtcp2 libraries can end up ABI-incompatible.
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get full-upgrade -y
 pkg install -y proot-distro git curl pulseaudio wget screen
 log "Termux packages installed."
 
@@ -315,8 +319,32 @@ cat > "$PREFIX/bin/easyproxy-update" << 'UPD_EOF'
 set -Eeuo pipefail
 echo "Running full EasyProxy system update..."
 easyproxy-stop 2>/dev/null || true
-curl -fsSL --retry 3 --connect-timeout 20 \
-    "https://raw.githubusercontent.com/realbestia1/EasyProxy/main/termux_setup.sh?$(date +%s)" | bash
+
+echo "Updating Termux packages..."
+# Use apt-get directly: the pkg wrapper depends on curl and cannot repair a
+# partially upgraded Termux installation when curl itself no longer starts.
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get full-upgrade -y
+
+SETUP_URL="https://raw.githubusercontent.com/realbestia1/EasyProxy/main/termux_setup.sh?$(date +%s)"
+SETUP_SCRIPT="$(mktemp)"
+cleanup() {
+    rm -f -- "$SETUP_SCRIPT"
+}
+trap cleanup EXIT
+
+if command -v curl >/dev/null 2>&1 && \
+        curl -fsSL --retry 3 --connect-timeout 20 -o "$SETUP_SCRIPT" "$SETUP_URL"; then
+    :
+elif command -v wget >/dev/null 2>&1 && \
+        wget -q --tries=3 --timeout=20 -O "$SETUP_SCRIPT" "$SETUP_URL"; then
+    :
+else
+    echo "Unable to download the EasyProxy setup script with curl or wget." >&2
+    exit 1
+fi
+
+bash "$SETUP_SCRIPT"
 echo "EasyProxy system updated successfully!"
 easyproxy
 UPD_EOF


### PR DESCRIPTION
## Summary

- support proot-distro 5 by selecting the Ubuntu 24.04 image when required
- install Python dependencies in an isolated virtual environment
- make launch, stop, logs, and update flows safer and more reliable
- recover updates from partially upgraded Termux environments with a `wget` fallback when `curl` is broken
- keep clone, setup, and updater URLs pointed at the original `realbestia1/EasyProxy` repository

## Verification

- `bash -n termux_setup.sh`
- `git diff --check upstream/main..HEAD`