### PR TITLE
Integrate embedded Toastflix sidecar

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,13 +14,11 @@ logging.basicConfig(
 # Aggiungi path corrente per import moduli
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-_IS_PROCESS_POOL_WORKER = __name__ == "__mp_main__"
-
-if not _IS_PROCESS_POOL_WORKER:
-    from services.proxy import HLSProxy
-    from config import PORT, RECORDINGS_DIR, APP_VERSION
-    from services.recording_manager import RecordingManager
-    from routes.recordings import setup_recording_routes
+from services.proxy import HLSProxy
+from config import PORT, RECORDINGS_DIR, APP_VERSION
+from services.recording_manager import RecordingManager
+from services.sidecar_manager import SidecarManager
+from routes.recordings import setup_recording_routes
 
 logger = logging.getLogger(__name__)
 
@@ -32,10 +30,13 @@ def _read_file(path):
 # --- Logica di Avvio ---
 def create_app():
     """Crea e configura l'applicazione aiohttp."""
-    proxy = HLSProxy()
+    sidecar_cache_dir = os.path.join(RECORDINGS_DIR, "sidecar_data")
+    sidecar_manager = SidecarManager(cache_dir=sidecar_cache_dir)
+    proxy = HLSProxy(sidecar_manager=sidecar_manager)
 
     app = web.Application()
     app['proxy'] = proxy
+    app['sidecar_manager'] = sidecar_manager
 
     # Initialize recording manager for DVR functionality
     recording_manager = RecordingManager(
@@ -108,6 +109,17 @@ def create_app():
     # ✅ Health check endpoint
     app.router.add_get('/health', lambda r: web.json_response({"status": "ok", "version": APP_VERSION}))
 
+    # Toastflix aiohttp sidecar, kept private and exposed through this process.
+    app.router.add_route('*', '/sidecar', proxy.handle_sidecar_request)
+    app.router.add_route('*', '/sidecar/{tail:.*}', proxy.handle_sidecar_request)
+
+    # Root aliases for Toastflix clients that append /session, /dual, etc.
+    # directly to the configured EasyProxy base URL.
+    app.router.add_route('*', '/session', proxy.handle_sidecar_root_request)
+    app.router.add_route('*', '/dual/{tail:.*}', proxy.handle_sidecar_root_request)
+    app.router.add_route('*', '/offset/{tail:.*}', proxy.handle_sidecar_root_request)
+    app.router.add_route('*', '/sync', proxy.handle_sidecar_root_request)
+
     # Admin Panel
     app.router.add_get('/admin', proxy.handle_admin)
     app.router.add_get('/admin/login', proxy.handle_admin_login)
@@ -132,19 +144,23 @@ def create_app():
     app.on_cleanup.append(cleanup_handler)
     
     async def on_startup(app):
-        await proxy.start_tasks()
-        recording_manager.start_cleanup_loop()
+        # The sidecar is started lazily by the first /sidecar request and is
+        # stopped after 1 hour without activity.
+        asyncio.create_task(proxy.start_tasks())
+        asyncio.create_task(recording_manager.cleanup_loop())
     app.on_startup.append(on_startup)
 
     async def on_shutdown(app):
-        await recording_manager.shutdown()
+        try:
+            await recording_manager.shutdown()
+        finally:
+            await sidecar_manager.stop()
     app.on_shutdown.append(on_shutdown)
     
     return app
 
-# I worker PoW di ProcessPoolExecutor su Windows importano il modulo principale
-# come __mp_main__. Non devono inizializzare server, registry e database.
-app = None if _IS_PROCESS_POOL_WORKER else create_app()
+# Crea l'istanza "privata" dell'applicazione aiohttp.
+app = create_app()
 
 def main():
     """Funzione principale per avviare il server."""

--- a/services/proxy.py
+++ b/services/proxy.py
@@ -7,6 +7,8 @@ from services.proxy_dash import HLSProxyDashMixin
 from services.proxy_handlers import HLSProxyHandlersMixin
 from services.proxy_pages import HLSProxyPagesMixin
 from services.proxy_streaming import HLSProxyStreamingMixin
+from services.proxy_sidecar import HLSProxySidecarMixin
+from services.sidecar_manager import SidecarManager
 
 # ContextVars to isolate extractor state per request/asyncio task to avoid concurrent request interference
 _extractors_var = contextvars.ContextVar("extractors", default=None)
@@ -15,6 +17,7 @@ _extractor_stream_atimes_var = contextvars.ContextVar("extractor_stream_atimes",
 
 
 class HLSProxy(
+    HLSProxySidecarMixin,
     HLSProxyCoreMixin,
     HLSProxyHandlersMixin,
     HLSProxyDashMixin,
@@ -59,7 +62,7 @@ class HLSProxy(
     def _extractor_stream_atimes(self, value):
         _extractor_stream_atimes_var.set(value)
 
-    def __init__(self):
+    def __init__(self, sidecar_manager: SidecarManager | None = None):
         # Note: self.extractors, self._extractor_atimes, and self._extractor_stream_atimes 
         # are lazily initialized per asyncio task context to prevent concurrent request race conditions.
 
@@ -72,7 +75,6 @@ class HLSProxy(
 
         # Prefetch queue for background downloading (kept for prefetch logic, no segment cache storage)
         self.prefetch_tasks = set()
-        self._background_tasks = set()
         self._prefetch_semaphore = asyncio.Semaphore(5)
         self._prefetch_lock = asyncio.Lock()
 
@@ -94,6 +96,9 @@ class HLSProxy(
         self.latest_version = "Checking..."
         self.warp_status = "Checking..."
         self._warp_ip = ""
+
+        if sidecar_manager is not None:
+            self._init_sidecar_proxy(sidecar_manager)
 
 
 

--- a/services/proxy_sidecar.py
+++ b/services/proxy_sidecar.py
@@ -1,0 +1,156 @@
+"""Reverse proxy for the embedded Toastflix aiohttp sidecar."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import aiohttp
+from aiohttp import web
+
+if TYPE_CHECKING:
+    from services.sidecar_manager import SidecarManager
+
+
+_HOP_BY_HOP_HEADERS = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+}
+
+
+class HLSProxySidecarMixin:
+    """Forward ``/sidecar`` requests to the private aiohttp process."""
+
+    def _init_sidecar_proxy(self, manager: "SidecarManager") -> None:
+        self.sidecar_manager = manager
+        self._sidecar_session: aiohttp.ClientSession | None = None
+
+    async def _get_sidecar_session(self) -> aiohttp.ClientSession:
+        session = getattr(self, "_sidecar_session", None)
+        if session is None or session.closed:
+            session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(
+                    total=None,
+                    connect=10,
+                    sock_connect=10,
+                    sock_read=None,
+                ),
+                connector=aiohttp.TCPConnector(limit=100),
+                auto_decompress=False,
+            )
+            self._sidecar_session = session
+        return session
+
+    async def _proxy_sidecar_request(
+        self,
+        request: web.Request,
+        external_prefix: str,
+    ) -> web.StreamResponse:
+        manager = getattr(self, "sidecar_manager", None)
+        if manager is None:
+            return web.json_response(
+                {"detail": "Toastflix sidecar is not available"}, status=503
+            )
+
+        request_started = False
+        try:
+            await manager.begin_request()
+            request_started = True
+        except Exception as exc:
+            return web.json_response(
+                {"detail": f"Toastflix sidecar is not available: {exc}"},
+                status=503,
+            )
+
+        try:
+            path, _, raw_query = request.raw_path.partition("?")
+            if external_prefix and path == external_prefix:
+                sidecar_path = "/"
+            elif external_prefix and path.startswith(f"{external_prefix}/"):
+                sidecar_path = path[len(external_prefix):] or "/"
+            else:
+                # This branch is only a defensive fallback for direct unit calls.
+                sidecar_path = path or "/"
+                if external_prefix:
+                    tail = request.match_info.get("tail", "")
+                    sidecar_path = f"/{tail}" if tail else "/"
+                    raw_query = request.query_string
+            target_url = manager.target_url(sidecar_path, raw_query)
+
+            headers = {
+                key: value
+                for key, value in request.headers.items()
+                if key.lower() not in _HOP_BY_HOP_HEADERS
+                and key.lower() not in {"host", "content-length"}
+            }
+            remote = request.remote or ""
+            existing_forwarded_for = request.headers.get("X-Forwarded-For", "").strip()
+            forwarded_for = ", ".join(item for item in (existing_forwarded_for, remote) if item)
+            if forwarded_for:
+                headers["X-Forwarded-For"] = forwarded_for
+            forwarded_host = (
+                request.headers.get("X-Forwarded-Host", "").split(",", 1)[0].strip()
+                or request.host
+            )
+            forwarded_proto = (
+                request.headers.get("X-Forwarded-Proto", "").split(",", 1)[0].strip()
+                or request.scheme
+            )
+            # The sidecar uses the actual Host header for its public base URL. Keep the
+            # public host here, otherwise generated audio URLs expose 127.0.0.1
+            # and the child's random internal port to Toastflix.
+            headers["Host"] = forwarded_host
+            headers["X-Forwarded-Host"] = forwarded_host
+            headers["X-Forwarded-Proto"] = forwarded_proto
+            headers["X-Forwarded-Prefix"] = external_prefix
+
+            body = await request.read()
+            session = await self._get_sidecar_session()
+            async with session.request(
+                request.method,
+                target_url,
+                headers=headers,
+                data=body if body else None,
+                allow_redirects=False,
+            ) as upstream:
+                downstream = web.StreamResponse(status=upstream.status, reason=upstream.reason)
+                for key, value in upstream.headers.items():
+                    if key.lower() not in _HOP_BY_HOP_HEADERS and key.lower() != "content-length":
+                        downstream.headers.add(key, value)
+                await downstream.prepare(request)
+                async for chunk in upstream.content.iter_chunked(64 * 1024):
+                    await downstream.write(chunk)
+                await downstream.write_eof()
+                return downstream
+        except asyncio.CancelledError:
+            raise
+        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            return web.json_response(
+                {"detail": f"Toastflix sidecar request failed: {exc}"}, status=502
+            )
+        finally:
+            if request_started:
+                await manager.end_request()
+
+    async def handle_sidecar_request(self, request: web.Request) -> web.StreamResponse:
+        """Handle the backwards-compatible ``/sidecar/*`` namespace."""
+        return await self._proxy_sidecar_request(request, "/sidecar")
+
+    async def handle_sidecar_root_request(self, request: web.Request) -> web.StreamResponse:
+        """Handle Toastflix clients configured with EasyProxy's base URL."""
+        return await self._proxy_sidecar_request(request, "")
+
+    async def cleanup(self):
+        session = getattr(self, "_sidecar_session", None)
+        if session is not None and not session.closed:
+            await session.close()
+        await super().cleanup()
+
+
+__all__ = ["HLSProxySidecarMixin"]

--- a/services/sidecar_manager.py
+++ b/services/sidecar_manager.py
@@ -1,0 +1,251 @@
+"""Lifecycle management for the embedded Toastflix audio sidecar."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import socket
+import sys
+from pathlib import Path
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+
+class SidecarManager:
+    """Start, health-check, and stop the embedded aiohttp sidecar process.
+
+    The sidecar is deliberately bound to loopback.  EasyProxy is the only
+    public entry point and forwards requests to the child process through the
+    :class:`HLSProxySidecarMixin`.
+    """
+
+    IDLE_TIMEOUT_SECONDS = 5 * 60
+
+    def __init__(
+        self,
+        cache_dir: str | os.PathLike[str] | None = None,
+    ):
+        project_dir = Path(__file__).resolve().parent.parent
+        self.project_dir = project_dir
+        self.sidecar_module = "services.toastflix_sidecar.app"
+        self.cache_dir = Path(
+            cache_dir or project_dir / "recordings" / "sidecar_data"
+        ).resolve()
+
+        self.host = "127.0.0.1"
+        self.configured_port = 0
+        self.startup_timeout = 20.0
+
+        self.process: asyncio.subprocess.Process | None = None
+        self.port: int | None = None
+        self._log_task: asyncio.Task | None = None
+        self._child_output: list[str] = []
+        self._lifecycle_lock = asyncio.Lock()
+        self._idle_handle: asyncio.TimerHandle | None = None
+        self._last_activity: float | None = None
+        self._active_requests = 0
+
+    @property
+    def running(self) -> bool:
+        return self.process is not None and self.process.returncode is None and self.port is not None
+
+    @property
+    def base_url(self) -> str:
+        if self.port is None:
+            raise RuntimeError("Sidecar is not running")
+        return f"http://{self.host}:{self.port}"
+
+    def target_url(self, path: str, query_string: str = "") -> str:
+        """Build an internal URL while keeping the original query encoding."""
+        if not path.startswith("/"):
+            path = f"/{path}"
+        target = f"{self.base_url}{path}"
+        return f"{target}?{query_string}" if query_string else target
+
+    async def start(self) -> None:
+        """Launch the sidecar and wait until its health endpoint responds."""
+        async with self._lifecycle_lock:
+            if self.running:
+                self._touch_unlocked()
+                return
+            await self._start_unlocked()
+
+    async def begin_request(self) -> None:
+        """Start the sidecar on demand and keep it alive for this request."""
+        async with self._lifecycle_lock:
+            if not self.running:
+                await self._start_unlocked()
+            self._active_requests += 1
+            self._touch_unlocked()
+
+    async def end_request(self) -> None:
+        """Release a request and restart the idle-shutdown countdown."""
+        async with self._lifecycle_lock:
+            self._active_requests = max(0, self._active_requests - 1)
+            if self.running:
+                self._touch_unlocked()
+
+    async def _start_unlocked(self) -> None:
+        if self.process is not None:
+            await self._stop_unlocked()
+        sidecar_app = self.project_dir / "services" / "toastflix_sidecar" / "app.py"
+        if not sidecar_app.is_file():
+            raise FileNotFoundError(f"Embedded Toastflix sidecar not found: {sidecar_app}")
+
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.port = self.configured_port or self._find_free_port()
+        self._child_output.clear()
+        child_env = os.environ.copy()
+
+        command = [
+            sys.executable,
+            "-m",
+            self.sidecar_module,
+            "--host",
+            self.host,
+            "--port",
+            str(self.port),
+            "--cache-dir",
+            str(self.cache_dir),
+        ]
+        logger.info(
+            "Starting Toastflix sidecar on %s:%s (cache: %s)",
+            self.host,
+            self.port,
+            self.cache_dir,
+        )
+        try:
+            self.process = await asyncio.create_subprocess_exec(
+                *command,
+                cwd=str(self.project_dir),
+                env=child_env,
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            self._log_task = asyncio.create_task(self._read_output())
+            await self._wait_until_ready()
+        except Exception:
+            await self._stop_unlocked()
+            raise
+
+        logger.info("Toastflix sidecar is ready at %s", self.base_url)
+        self._touch_unlocked()
+
+    async def stop(self) -> None:
+        """Stop the child process and its output reader without leaving orphans."""
+        async with self._lifecycle_lock:
+            await self._stop_unlocked()
+
+    async def _stop_unlocked(self) -> None:
+        if self._idle_handle is not None:
+            self._idle_handle.cancel()
+            self._idle_handle = None
+
+        process = self.process
+        if process is not None and process.returncode is None:
+            logger.info("Stopping Toastflix sidecar (pid=%s)", process.pid)
+            process.terminate()
+            try:
+                await asyncio.wait_for(process.wait(), timeout=5)
+            except asyncio.TimeoutError:
+                logger.warning("Toastflix sidecar did not stop cleanly; killing it")
+                process.kill()
+                await process.wait()
+
+        if self._log_task is not None:
+            self._log_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._log_task
+
+        self._log_task = None
+        self.process = None
+        self.port = None
+        self._last_activity = None
+        self._active_requests = 0
+
+    def _touch_unlocked(self) -> None:
+        self._last_activity = asyncio.get_running_loop().time()
+        if self._idle_handle is not None:
+            self._idle_handle.cancel()
+        self._idle_handle = asyncio.get_running_loop().call_later(
+            self.IDLE_TIMEOUT_SECONDS,
+            self._idle_timeout_callback,
+        )
+
+    def _idle_timeout_callback(self) -> None:
+        self._idle_handle = None
+        asyncio.create_task(self._stop_if_idle())
+
+    async def _stop_if_idle(self) -> None:
+        async with self._lifecycle_lock:
+            if not self.running:
+                return
+            if self._active_requests:
+                self._touch_unlocked()
+                return
+            last_activity = self._last_activity or 0.0
+            idle_for = asyncio.get_running_loop().time() - last_activity
+            if idle_for < self.IDLE_TIMEOUT_SECONDS:
+                self._idle_handle = asyncio.get_running_loop().call_later(
+                    self.IDLE_TIMEOUT_SECONDS - idle_for,
+                    self._idle_timeout_callback,
+                )
+                return
+            logger.info(
+                "Stopping Toastflix sidecar after %s seconds without requests",
+                self.IDLE_TIMEOUT_SECONDS,
+            )
+            await self._stop_unlocked()
+
+    def _find_free_port(self) -> int:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind((self.host, 0))
+            return int(sock.getsockname()[1])
+
+    async def _wait_until_ready(self) -> None:
+        deadline = asyncio.get_running_loop().time() + self.startup_timeout
+        timeout = aiohttp.ClientTimeout(total=2)
+        health_url = f"{self.base_url}/health"
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            while asyncio.get_running_loop().time() < deadline:
+                if self.process is None or self.process.returncode is not None:
+                    code = None if self.process is None else self.process.returncode
+                    details = "\n".join(self._child_output[-20:])
+                    message = f"Toastflix sidecar exited before readiness (code={code})"
+                    if details:
+                        message += f"\nSidecar output:\n{details}"
+                    raise RuntimeError(message)
+                try:
+                    async with session.get(health_url) as response:
+                        if response.status == 200:
+                            return
+                except (aiohttp.ClientError, asyncio.TimeoutError):
+                    pass
+                await asyncio.sleep(0.1)
+        raise TimeoutError(f"Toastflix sidecar did not become ready within {self.startup_timeout:g}s")
+
+    async def _read_output(self) -> None:
+        process = self.process
+        if process is None or process.stdout is None:
+            return
+        try:
+            async for raw_line in process.stdout:
+                line = raw_line.decode(errors="replace").rstrip()
+                if line:
+                    self._child_output.append(line)
+                    if len(self._child_output) > 100:
+                        del self._child_output[:-100]
+                    logger.info("[sidecar] %s", line)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.debug("Unable to read Toastflix sidecar output: %s", exc)
+
+
+__all__ = ["SidecarManager"]

--- a/services/toastflix_sidecar/__init__.py
+++ b/services/toastflix_sidecar/__init__.py
@@ -1,0 +1,1 @@
+"""Embedded Toastflix audio sidecar package for EasyProxy."""

--- a/services/toastflix_sidecar/app.py
+++ b/services/toastflix_sidecar/app.py
@@ -1,0 +1,310 @@
+"""Aiohttp server for the embedded Toastflix audio sidecar.
+
+The audio, offset and synchronisation engines are framework-independent. This
+module only exposes them over HTTP, using the aiohttp stack already required by
+EasyProxy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from urllib.parse import urlencode
+
+from aiohttp import web
+
+from .audio import AudioStore
+from .offsets import OffsetStore
+from .security import SessionManager, request_token, resolves_publicly
+from .sync import SyncEngine
+
+
+logger = logging.getLogger("toastflix_sidecar")
+APP_DIR = Path(__file__).resolve().parent
+DOCKER_CACHE_DIR = Path("/data/recordings/sidecar_data")
+DEFAULT_CACHE_DIR = DOCKER_CACHE_DIR if Path("/data").is_dir() else APP_DIR / "data"
+SESSION_TTL = 21600
+
+sessions = SessionManager(SESSION_TTL)
+audio = None
+offsets = None
+sync_engine = None
+
+
+def _configure_cache(cache_dir: str | Path) -> None:
+    global audio, offsets, sync_engine
+    cache_path = Path(cache_dir)
+    cache_path.mkdir(parents=True, exist_ok=True)
+    audio = AudioStore(str(cache_path / "audio"))
+    offsets = OffsetStore(str(cache_path / "offsets.db"))
+    sync_engine = SyncEngine(audio, offsets)
+
+
+_configure_cache(DEFAULT_CACHE_DIR)
+
+
+class SidecarError(Exception):
+    def __init__(self, status: int, detail: str):
+        super().__init__(detail)
+        self.status = status
+        self.detail = detail
+
+
+def _json(data, status: int = 200) -> web.Response:
+    return web.json_response(data, status=status)
+
+
+async def _json_body(request: web.Request) -> dict:
+    try:
+        body = await request.json()
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as exc:
+        raise SidecarError(400, "invalid JSON body") from exc
+    if not isinstance(body, dict):
+        raise SidecarError(400, "JSON body must be an object")
+    return body
+
+
+def _query_int(request: web.Request, name: str, default: int) -> int:
+    value = request.query.get(name, str(default))
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise SidecarError(422, f"invalid query parameter: {name}") from exc
+
+
+def _require_session(request: web.Request, body: dict | None = None) -> str:
+    token = request_token(request, body)
+    if not sessions.valid(token):
+        raise SidecarError(401, "sidecar session required")
+    return token
+
+
+def _base_url(request: web.Request) -> str:
+    # EasyProxy supplies these headers when forwarding a public request. This
+    # Reconstruct the public URL from the headers added by EasyProxy.
+    scheme = request.headers.get("X-Forwarded-Proto", request.scheme).split(",", 1)[0].strip()
+    host = request.headers.get("X-Forwarded-Host", request.host).split(",", 1)[0].strip()
+    prefix = request.headers.get("X-Forwarded-Prefix", "").split(",", 1)[0].strip().rstrip("/")
+    return f"{scheme}://{host}{prefix}"
+
+
+def _audio_url(request: web.Request, hid: str, token: str, offset: float = 0.0, rate: float = 1.0) -> str:
+    query = urlencode({"o": int(round(offset * 1000)), "r": int(round(rate * 1_000_000_000)), "t": token})
+    return f"{_base_url(request)}/dual/aud/{hid}/audio.m3u8?{query}"
+
+
+def _audio_response(data: bytes, media_type: str, cache_control: str = "no-store") -> web.Response:
+    return web.Response(
+        body=data,
+        headers={
+            "Content-Type": media_type,
+            "Access-Control-Allow-Origin": "*",
+            "Cache-Control": cache_control,
+            "Accept-Ranges": "bytes",
+        },
+    )
+
+
+async def health(request: web.Request) -> web.Response:
+    return _json({"status": "ok", "service": "toast-audio-sidecar", "public_url": None})
+
+
+async def create_session(request: web.Request) -> web.Response:
+    sessions.cleanup()
+    token, expires_at = sessions.issue()
+    return _json({"token": token, "expires_at": expires_at, "ttl_seconds": sessions.ttl_seconds})
+
+
+async def prepare_audio(request: web.Request) -> web.Response:
+    body = await _json_body(request)
+    token = _require_session(request, body)
+    try:
+        hid = await audio.register(
+            playlist=str(body.get("playlist") or ""),
+            key_b64=str(body.get("key") or ""),
+            media_key=str(body.get("mediaKey") or ""),
+            language=str(body.get("lang") or ""),
+            base_url=str(body.get("baseUrl") or ""),
+            headers=body.get("headers") if isinstance(body.get("headers"), dict) else {},
+        )
+        metadata = audio.metadata(hid)
+        for url in (metadata["segs"][0], metadata["segs"][-1]):
+            if not await resolves_publicly(url):
+                raise ValueError("audio source does not resolve publicly")
+    except (ValueError, OSError, json.JSONDecodeError) as exc:
+        raise SidecarError(400, str(exc)) from exc
+    metadata = audio.metadata(hid)
+    return _json({
+        "hid": hid,
+        "url": _audio_url(request, hid, token),
+        "language": str(body.get("lang") or "").lower(),
+        "audio_fingerprint": metadata.get("source_fingerprint", ""),
+    })
+
+
+async def cached_audio(request: web.Request) -> web.Response:
+    body = await _json_body(request)
+    token = _require_session(request, body)
+    hid = audio.find_cached(str(body.get("mediaKey") or ""), str(body.get("lang") or "").lower())
+    if not hid:
+        raise SidecarError(404, "valid cached audio track not found")
+    metadata = audio.metadata(hid)
+    return _json({
+        "url": _audio_url(request, hid, token),
+        "cached": True,
+        "hid": hid,
+        "audio_fingerprint": metadata.get("source_fingerprint", ""),
+    })
+
+
+async def audio_playlist(request: web.Request) -> web.Response:
+    hid = request.match_info["hid"]
+    token = _require_session(request)
+    offset_ms = _query_int(request, "o", 0)
+    rate_nano = _query_int(request, "r", 1_000_000_000)
+    try:
+        metadata = audio.metadata(hid)
+        offset, rate = offset_ms / 1000.0, rate_nano / 1_000_000_000
+        timeline = audio.timeline(metadata, offset, rate)
+        if not timeline:
+            raise ValueError("empty audio timeline")
+        base = _base_url(request)
+        lines = [
+            "#EXTM3U",
+            "#EXT-X-VERSION:7",
+            "#EXT-X-PLAYLIST-TYPE:VOD",
+            f"#EXT-X-TARGETDURATION:{int(max(item['duration'] for item in timeline)) + 1}",
+            "#EXT-X-MEDIA-SEQUENCE:0",
+            f'#EXT-X-MAP:URI="{base}/dual/aud/{hid}/init.mp4?{urlencode({"o": offset_ms, "r": rate_nano, "t": token})}"',
+        ]
+        for item in timeline:
+            query = urlencode({"o": offset_ms, "r": rate_nano, "t": token})
+            lines += [
+                f"#EXTINF:{item['duration']:.6f},",
+                f"{base}/dual/aud/{hid}/s{item['idx']}.m4s?{query}",
+            ]
+        lines.append("#EXT-X-ENDLIST")
+        return web.Response(
+            text="\n".join(lines) + "\n",
+            content_type="application/vnd.apple.mpegurl",
+            headers={"Access-Control-Allow-Origin": "*", "Cache-Control": "no-cache"},
+        )
+    except (ValueError, FileNotFoundError) as exc:
+        raise SidecarError(404, str(exc)) from exc
+
+
+async def audio_init(request: web.Request) -> web.Response:
+    hid = request.match_info["hid"]
+    _require_session(request)
+    offset_ms = _query_int(request, "o", 0)
+    rate_nano = _query_int(request, "r", 1_000_000_000)
+    try:
+        metadata = audio.metadata(hid)
+        timeline = audio.timeline(metadata, offset_ms / 1000.0, rate_nano / 1_000_000_000)
+        if not timeline:
+            raise ValueError("empty audio timeline")
+        init_data, _ = await audio.fragment_bytes(hid, timeline[0]["idx"], offset_ms / 1000.0, rate_nano / 1_000_000_000)
+        return _audio_response(init_data, "video/mp4")
+    except (ValueError, FileNotFoundError, RuntimeError) as exc:
+        raise SidecarError(404, str(exc)) from exc
+
+
+async def audio_segment(request: web.Request) -> web.Response:
+    hid = request.match_info["hid"]
+    index = int(request.match_info["idx"])
+    _require_session(request)
+    offset_ms = _query_int(request, "o", 0)
+    rate_nano = _query_int(request, "r", 1_000_000_000)
+    try:
+        _, fragment_data = await audio.fragment_bytes(hid, index, offset_ms / 1000.0, rate_nano / 1_000_000_000)
+        return _audio_response(fragment_data, "video/iso.segment")
+    except (ValueError, FileNotFoundError, RuntimeError) as exc:
+        raise SidecarError(404, str(exc)) from exc
+
+
+async def offset_lookup(request: web.Request) -> web.Response:
+    body = await _json_body(request)
+    _require_session(request, body)
+    result = await offsets.lookup(body)
+    return _json({"found": bool(result), "offset": result})
+
+
+async def offset_report(request: web.Request) -> web.Response:
+    body = await _json_body(request)
+    _require_session(request, body)
+    result = body.get("offset")
+    if not isinstance(result, dict):
+        raise SidecarError(400, "offset result required")
+    await offsets.report(body, result)
+    return _json({"ok": True})
+
+
+async def sync_audio(request: web.Request) -> web.Response:
+    body = await _json_body(request)
+    _require_session(request, body)
+    try:
+        result = await sync_engine.measure(body)
+    except (ValueError, FileNotFoundError, RuntimeError) as exc:
+        raise SidecarError(422, str(exc)) from exc
+    await offsets.report(body, result)
+    return _json(result)
+
+
+@web.middleware
+async def sidecar_middleware(request: web.Request, handler) -> web.StreamResponse:
+    if request.method == "OPTIONS":
+        response: web.StreamResponse = web.Response(status=200)
+    else:
+        try:
+            response = await handler(request)
+        except SidecarError as exc:
+            response = _json({"detail": exc.detail}, status=exc.status)
+        except web.HTTPException as exc:
+            response = _json({"detail": exc.reason}, status=exc.status)
+        except Exception:
+            logger.exception("Unhandled sidecar request error")
+            response = _json({"detail": "internal sidecar error"}, status=500)
+
+    response.headers["Access-Control-Allow-Origin"] = "*"
+    response.headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
+    response.headers["Access-Control-Allow-Headers"] = "*"
+    return response
+
+
+app = web.Application(middlewares=[sidecar_middleware])
+app.router.add_get("/health", health)
+app.router.add_post("/session", create_session)
+app.router.add_post("/dual/aprep", prepare_audio)
+app.router.add_post("/dual/acache", cached_audio)
+app.router.add_get("/dual/aud/{hid}/audio.m3u8", audio_playlist)
+app.router.add_get("/dual/aud/{hid}/init.mp4", audio_init)
+app.router.add_get(r"/dual/aud/{hid}/s{idx:\d+}.m4s", audio_segment)
+app.router.add_post("/offset/lookup", offset_lookup)
+app.router.add_post("/offset/report", offset_report)
+app.router.add_post("/sync", sync_audio)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Toast Audio Sidecar")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=3107)
+    parser.add_argument("--cache-dir", default=str(DEFAULT_CACHE_DIR))
+    args = parser.parse_args()
+    _configure_cache(args.cache_dir)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+    )
+    logging.getLogger("aiohttp.access").setLevel(logging.INFO)
+    web.run_app(
+        app,
+        host=args.host,
+        port=args.port,
+        access_log=logging.getLogger("aiohttp.access"),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/toastflix_sidecar/audio.py
+++ b/services/toastflix_sidecar/audio.py
@@ -1,0 +1,308 @@
+import asyncio
+import base64
+import hashlib
+import json
+import re
+import struct
+import tempfile
+import time
+import weakref
+from pathlib import Path
+from urllib.parse import urljoin, urlparse
+
+from .security import resolves_publicly, valid_public_url
+from .http_client import client_session
+
+
+class AudioStore:
+    """Hold audio metadata in memory and never persist audio fragments.
+
+    The sidecar is used as a personal service, so source audio and generated
+    fMP4 fragments are processed per request and removed with their temporary
+    working directory. Offset data remains persisted separately by OffsetStore.
+    """
+
+    TRACK_TTL_SECONDS = 21600
+    MAX_TRACKS = 128
+    MAX_REDIRECTS = 5
+    MAX_SEGMENT_BYTES = 20 * 1024 * 1024
+
+    def __init__(self, root: str, proxy: str = "", max_bytes: int | None = None):
+        self.proxy = proxy.strip()
+        # A weak map keeps per-track locks only while a request still holds a
+        # reference to them. It cannot grow permanently with every new HID.
+        self._locks: weakref.WeakValueDictionary[str, asyncio.Lock] = weakref.WeakValueDictionary()
+        self._tracks: dict[str, dict] = {}
+
+    def _lock(self, hid: str):
+        return self._locks.setdefault(hid, asyncio.Lock())
+
+    def _track(self, hid: str) -> dict:
+        if not re.fullmatch(r"[0-9a-f]{16}", hid):
+            raise ValueError("invalid audio id")
+        track = self._tracks.get(hid)
+        if track is None:
+            raise FileNotFoundError("audio track not found")
+        track["last_used"] = time.monotonic()
+        return track
+
+    def _remember(self, hid: str, metadata: dict, key: bytes) -> None:
+        now = time.monotonic()
+        self._tracks[hid] = {
+            "metadata": metadata,
+            "key": key,
+            "last_used": now,
+        }
+        expired = [
+            key_id
+            for key_id, track in self._tracks.items()
+            if now - track["last_used"] > self.TRACK_TTL_SECONDS
+        ]
+        for key_id in expired:
+            self._tracks.pop(key_id, None)
+        while len(self._tracks) > self.MAX_TRACKS:
+            oldest = min(self._tracks, key=lambda key_id: self._tracks[key_id]["last_used"])
+            self._tracks.pop(oldest, None)
+
+    @staticmethod
+    def _parse_playlist(playlist: str, base_url: str = ""):
+        segments, durations = [], []
+        pending = None
+        key_line = ""
+        for raw in playlist.splitlines():
+            line = raw.strip()
+            if line.startswith("#EXT-X-KEY:"):
+                key_line = line
+            elif line.startswith("#EXTINF:"):
+                pending = float(line.split(":", 1)[1].split(",", 1)[0])
+            elif pending is not None and line and not line.startswith("#"):
+                segments.append(urljoin(base_url, line))
+                durations.append(pending)
+                pending = None
+        return segments, durations, key_line
+
+    @staticmethod
+    def _validate_segments(segments):
+        if not segments or len(segments) > 10000:
+            raise ValueError("invalid audio segment count")
+        if not all(valid_public_url(url) for url in segments):
+            raise ValueError("audio segment URL is not public HTTPS")
+
+    async def register(self, playlist: str, key_b64: str, media_key: str,
+                       language: str, base_url: str = "", headers: dict | None = None):
+        if len(playlist) > 2 * 1024 * 1024 or "#EXTINF" not in playlist:
+            raise ValueError("invalid audio playlist")
+        language = str(language or "").lower().strip()
+        if language not in {"ita", "eng", "it", "en", "italian", "english"}:
+            raise ValueError("language must be ita or eng")
+        segments, durations, key_line = self._parse_playlist(playlist, base_url)
+        self._validate_segments(segments)
+        if len(durations) < len(segments):
+            raise ValueError("audio durations do not match segments")
+        key = base64.b64decode(key_b64, validate=True)
+        if len(key) != 16:
+            raise ValueError("AES key must be 16 bytes")
+        safe_headers = {
+            str(name): str(value).strip()
+            for name, value in (headers or {}).items()
+            if re.fullmatch(r"[A-Za-z0-9-]+", str(name))
+            and str(value).strip()
+            and len(str(value).strip()) <= 1024
+            and "\r" not in str(value)
+            and "\n" not in str(value)
+        }
+        stable = [urlparse(url).path for url in segments[:3]]
+        hid = hashlib.sha1(("|".join(stable) + str(len(segments)) + language).encode()).hexdigest()[:16]
+        async with self._lock(hid):
+            starts, total = [], 0.0
+            for duration in durations[:len(segments)]:
+                starts.append(total)
+                total += duration
+            metadata = {
+                "segs": segments,
+                "durs": durations[:len(segments)],
+                "starts": starts,
+                "iv": (re.search(r"IV=(0x[0-9A-Fa-f]+)", key_line) or [None, None])[1],
+                "media_key": str(media_key or ""),
+                "language": language,
+                "headers": safe_headers,
+                "source_fingerprint": hashlib.sha1(
+                    ("|".join(stable) + str(len(segments))).encode()
+                ).hexdigest()[:20],
+            }
+            self._remember(hid, metadata, key)
+        return hid
+
+    def metadata(self, hid: str):
+        return self._track(hid)["metadata"]
+
+    def key_bytes(self, hid: str) -> bytes:
+        return self._track(hid)["key"]
+
+    def find_cached(self, media_key: str, language: str):
+        # Persistent audio reuse is intentionally disabled. Toastflix will
+        # call /dual/aprep again and receive a fresh in-memory track.
+        return None
+
+    @staticmethod
+    def timeline(metadata: dict, offset: float = 0.0, rate: float = 1.0):
+        if not 0.998 <= rate <= 1.002:
+            raise ValueError("audio rate outside supported range")
+        entries = []
+        for index, (start, duration) in enumerate(zip(metadata["starts"], metadata["durs"])):
+            shifted = float(start) + float(offset)
+            trim = max(0.0, -shifted)
+            if trim >= float(duration) - 0.02:
+                continue
+            entries.append({"idx": index, "start": max(0.0, shifted / rate), "trim": trim, "duration": (float(duration) - trim) / rate})
+        return entries
+
+    async def _download(self, url: str, headers: dict, destination: Path):
+        current_url = url
+        async with client_session(self.proxy, timeout=30) as (client, request_proxy):
+            for redirect_count in range(self.MAX_REDIRECTS + 1):
+                if not valid_public_url(current_url) or not await resolves_publicly(current_url):
+                    raise ValueError("audio URL is not public HTTPS")
+                async with client.get(
+                    current_url,
+                    headers=headers,
+                    proxy=request_proxy,
+                    allow_redirects=False,
+                ) as response:
+                    if response.status in {301, 302, 303, 307, 308}:
+                        location = response.headers.get("Location", "").strip()
+                        if not location:
+                            raise ValueError("audio redirect has no location")
+                        next_url = urljoin(current_url, location)
+                        if not valid_public_url(next_url) or not await resolves_publicly(next_url):
+                            raise ValueError("audio redirect is not public HTTPS")
+                        if redirect_count >= self.MAX_REDIRECTS:
+                            raise ValueError("too many audio redirects")
+                        current_url = next_url
+                        continue
+
+                    response.raise_for_status()
+                    content_length = response.headers.get("Content-Length")
+                    if content_length:
+                        try:
+                            if int(content_length) > self.MAX_SEGMENT_BYTES:
+                                raise ValueError("audio segment too large")
+                        except ValueError as exc:
+                            if str(exc) == "audio segment too large":
+                                raise
+                            raise ValueError("invalid audio content length") from exc
+
+                    try:
+                        total = 0
+                        with destination.open("wb") as output:
+                            async for chunk in response.content.iter_chunked(64 * 1024):
+                                total += len(chunk)
+                                if total > self.MAX_SEGMENT_BYTES:
+                                    raise ValueError("audio segment too large")
+                                output.write(chunk)
+                    except Exception:
+                        destination.unlink(missing_ok=True)
+                        raise
+                    return total
+
+        raise ValueError("too many audio redirects")
+
+    @staticmethod
+    def _boxes(data: bytes, start=0, end=None):
+        end = len(data) if end is None else end
+        result, position = [], start
+        while position + 8 <= end:
+            size = struct.unpack(">I", data[position:position + 4])[0]
+            kind = data[position + 4:position + 8]
+            header = 8
+            if size == 1:
+                size = struct.unpack(">Q", data[position + 8:position + 16])[0]
+                header = 16
+            elif size == 0:
+                size = end - position
+            if size < header or position + size > end:
+                break
+            result.append((kind, position, size, header))
+            position += size
+        return result
+
+    @classmethod
+    def _find_box(cls, data, path, start=0, end=None):
+        for kind, position, size, header in cls._boxes(data, start, end):
+            if kind != path[0]:
+                continue
+            if len(path) == 1:
+                return position, size, header
+            found = cls._find_box(data, path[1:], position + header, position + size)
+            if found:
+                return found
+        return None
+
+    @classmethod
+    def _patch_time(cls, fragment: bytearray, timescale: int, start_seconds: float):
+        sidx = cls._find_box(bytes(fragment), [b"sidx"])
+        if sidx:
+            position, _, header = sidx
+            version = fragment[position + header]
+            sidx_timescale = struct.unpack(
+                ">I", fragment[position + header + 8:position + header + 12]
+            )[0]
+            value = int(round(start_seconds * sidx_timescale))
+            value_position = position + header + 12
+            if version == 1:
+                struct.pack_into(">Q", fragment, value_position, value)
+            else:
+                struct.pack_into(">I", fragment, value_position, value)
+        found = cls._find_box(bytes(fragment), [b"moof", b"traf", b"tfdt"])
+        if not found:
+            raise ValueError("tfdt box missing")
+        position, _, header = found
+        version = fragment[position + header]
+        value = int(round(start_seconds * timescale))
+        if version == 1:
+            struct.pack_into(">Q", fragment, position + header + 4, value)
+        else:
+            struct.pack_into(">I", fragment, position + header + 4, value)
+
+    async def fragment_bytes(self, hid: str, index: int, offset: float, rate: float):
+        metadata = self.metadata(hid)
+        timeline = self.timeline(metadata, offset, rate)
+        item = next((entry for entry in timeline if entry["idx"] == index), None)
+        if not item:
+            raise ValueError("audio segment outside timeline")
+        async with self._lock(hid):
+            with tempfile.TemporaryDirectory(prefix=f"sidecar-audio-{hid}-") as temp_dir:
+                work = Path(temp_dir)
+                await self._download(
+                    metadata["segs"][index],
+                    metadata.get("headers") or {},
+                    work / "src.ts",
+                )
+                (work / "enc.key").write_bytes(self.key_bytes(hid))
+                iv = f",IV={metadata['iv']}" if metadata.get("iv") else ""
+                (work / "input.m3u8").write_text(
+                    "#EXTM3U\n#EXT-X-VERSION:3\n"
+                    f"#EXT-X-TARGETDURATION:{int(metadata['durs'][index]) + 1}\n"
+                    f"#EXT-X-KEY:METHOD=AES-128,URI=\"enc.key\"{iv}\n"
+                    f"#EXTINF:{metadata['durs'][index]:.6f},\nsrc.ts\n#EXT-X-ENDLIST\n"
+                )
+                command = ["ffmpeg", "-v", "error", "-allowed_extensions", "ALL", "-protocol_whitelist", "file,crypto", "-i", "input.m3u8"]
+                if item["trim"] > 0.001:
+                    command += ["-ss", f"{item['trim']:.6f}"]
+                command += ["-c:a", "copy", "-bsf:a", "aac_adtstoasc", "-f", "hls", "-hls_time", "99999", "-hls_playlist_type", "vod", "-hls_segment_type", "fmp4", "-hls_fmp4_init_filename", "init.mp4", "-hls_segment_filename", "f%d.m4s", "-hls_list_size", "0", "-y", "output.m3u8"]
+                process = await asyncio.create_subprocess_exec(*command, cwd=work, stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.PIPE)
+                _, error = await asyncio.wait_for(process.communicate(), timeout=60)
+                made = work / "f0.m4s"
+                if process.returncode or not made.exists():
+                    raise RuntimeError((error.decode(errors="replace") or "ffmpeg failed")[:300])
+                init_data = (work / "init.mp4").read_bytes()
+                fragment = bytearray(made.read_bytes())
+                timescale = 48000
+                found = self._find_box(init_data, [b"moov", b"trak", b"mdia", b"mdhd"])
+                if found:
+                    position, _, header = found
+                    version = init_data[position + header]
+                    offset_pos = position + header + (20 if version == 1 else 12)
+                    timescale = struct.unpack(">I", init_data[offset_pos:offset_pos + 4])[0] or 48000
+                self._patch_time(fragment, timescale, item["start"])
+                return init_data, bytes(fragment)

--- a/services/toastflix_sidecar/http_client.py
+++ b/services/toastflix_sidecar/http_client.py
@@ -1,0 +1,42 @@
+"""Small aiohttp client helper shared by the embedded Toastflix sidecar."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+import aiohttp
+from aiohttp_socks import ProxyConnector
+
+
+def _proxy_settings(proxy: str):
+    proxy = str(proxy or "").strip()
+    if not proxy:
+        return None, None
+
+    connector_url = proxy
+    rdns = False
+    if connector_url.startswith("socks5h://"):
+        connector_url = connector_url.replace("socks5h://", "socks5://", 1)
+        rdns = True
+    elif connector_url.startswith("socks4a://"):
+        connector_url = connector_url.replace("socks4a://", "socks4://", 1)
+        rdns = True
+    elif connector_url.startswith("socks4://"):
+        rdns = False
+
+    if connector_url.startswith(("socks5://", "socks4://")):
+        return ProxyConnector.from_url(connector_url, rdns=rdns), None
+    return None, proxy
+
+
+@asynccontextmanager
+async def client_session(proxy: str = "", timeout: float = 30):
+    connector, request_proxy = _proxy_settings(proxy)
+    kwargs = {"timeout": aiohttp.ClientTimeout(total=timeout)}
+    if connector is not None:
+        kwargs["connector"] = connector
+    async with aiohttp.ClientSession(**kwargs) as session:
+        yield session, request_proxy
+
+
+__all__ = ["client_session"]

--- a/services/toastflix_sidecar/offsets.py
+++ b/services/toastflix_sidecar/offsets.py
@@ -1,0 +1,125 @@
+import asyncio
+import json
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+import aiohttp
+
+
+class OffsetStore:
+    """Local offset cache with an optional central VPS lookup/report endpoint."""
+
+    def __init__(self, path: str, api_url: str = "", api_token: str = ""):
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.api_url = api_url.rstrip("/")
+        self.api_token = api_token.strip()
+        self._init_db()
+
+    def _connect(self):
+        conn = sqlite3.connect(self.path, timeout=30)
+        conn.execute("PRAGMA busy_timeout=30000")
+        return conn
+
+    def _init_db(self):
+        with self._connect() as conn:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS offsets (
+                    cache_key TEXT PRIMARY KEY,
+                    media_key TEXT NOT NULL,
+                    resolution INTEGER NOT NULL,
+                    video_fingerprint TEXT NOT NULL,
+                    audio_fingerprint TEXT NOT NULL,
+                    offset_seconds REAL,
+                    rate REAL NOT NULL,
+                    confidence REAL NOT NULL,
+                    status TEXT NOT NULL,
+                    details TEXT NOT NULL,
+                    updated_at REAL NOT NULL
+                )
+            """)
+
+    @staticmethod
+    def key(media_key: str, resolution: int, video_fp: str, audio_fp: str) -> str:
+        import hashlib
+        return hashlib.sha1(
+            f"v2|{media_key}|{resolution}|{video_fp}|{audio_fp}".encode()
+        ).hexdigest()
+
+    def _local_get(self, cache_key: str):
+        with self._connect() as conn:
+            columns = [item[1] for item in conn.execute("PRAGMA table_info(offsets)")]
+            row = conn.execute(
+                "SELECT * FROM offsets WHERE cache_key = ?", (cache_key,)
+            ).fetchone()
+        if not row:
+            return None
+        result = dict(zip(columns, row))
+        result["details"] = json.loads(result.get("details") or "{}")
+        return result
+
+    async def lookup(self, payload: dict):
+        api_url = self.api_url
+        if not api_url and payload.get("vpsHost"):
+            api_url = f"{str(payload['vpsHost']).rstrip('/')}/dual/offset"
+        if api_url:
+            try:
+                headers = {"Authorization": f"Bearer {self.api_token}"} if self.api_token else {}
+                central_payload = dict(payload)
+                if payload.get("vpsAccess"):
+                    central_payload["access"] = payload["vpsAccess"]
+                timeout = aiohttp.ClientTimeout(total=8)
+                async with aiohttp.ClientSession(timeout=timeout) as client:
+                    async with client.post(
+                        f"{api_url}/lookup",
+                        json=central_payload,
+                        headers=headers,
+                    ) as response:
+                        if response.status == 200:
+                            data = await response.json(content_type=None)
+                            if data.get("found") and data.get("offset") is not None:
+                                return data["offset"]
+            except Exception:
+                pass
+        return await asyncio.to_thread(self._local_get, payload["cache_key"])
+
+    def _local_put(self, payload: dict, result: dict):
+        with self._connect() as conn:
+            conn.execute(
+                """INSERT OR REPLACE INTO offsets
+                (cache_key, media_key, resolution, video_fingerprint, audio_fingerprint,
+                 offset_seconds, rate, confidence, status, details, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    payload["cache_key"], payload["media_key"], payload["resolution"],
+                    payload["video_fingerprint"], payload["audio_fingerprint"],
+                    result.get("offset"), result.get("rate", 1.0),
+                    result.get("confidence", 0.0), result.get("status", "incompatible"),
+                    json.dumps(result, separators=(",", ":")), time.time(),
+                ),
+            )
+
+    async def report(self, payload: dict, result: dict):
+        await asyncio.to_thread(self._local_put, payload, result)
+        api_url = self.api_url
+        if not api_url and payload.get("vpsHost"):
+            api_url = f"{str(payload['vpsHost']).rstrip('/')}/dual/offset"
+        if not api_url:
+            return
+        try:
+            headers = {"Authorization": f"Bearer {self.api_token}"} if self.api_token else {}
+            central_payload = {**payload, "offset": result}
+            if payload.get("vpsAccess"):
+                central_payload["access"] = payload["vpsAccess"]
+            timeout = aiohttp.ClientTimeout(total=8)
+            async with aiohttp.ClientSession(timeout=timeout) as client:
+                async with client.post(
+                    f"{api_url}/report",
+                    json=central_payload,
+                    headers=headers,
+                ):
+                    pass
+        except Exception:
+            pass

--- a/services/toastflix_sidecar/security.py
+++ b/services/toastflix_sidecar/security.py
@@ -1,0 +1,105 @@
+import asyncio
+import hashlib
+import hmac
+import ipaddress
+import secrets
+import socket
+import time
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+
+def _host_is_public_shape(url: str, require_https: bool = True) -> bool:
+    parsed = urlparse(str(url or ""))
+    host = (parsed.hostname or "").strip().lower().rstrip(".")
+    if require_https and parsed.scheme != "https":
+        return False
+    if not require_https and parsed.scheme not in ("http", "https"):
+        return False
+    if (
+        not host
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.port not in (None, 80, 443)
+        or host in {"localhost", "localhost.localdomain"}
+        or host.endswith((".local", ".internal", ".home.arpa"))
+    ):
+        return False
+    try:
+        return ipaddress.ip_address(host).is_global
+    except ValueError:
+        return True
+
+
+def valid_public_url(url: str, require_https: bool = True) -> bool:
+    return _host_is_public_shape(url, require_https=require_https)
+
+
+async def resolves_publicly(url: str, require_https: bool = True) -> bool:
+    if not valid_public_url(url, require_https=require_https):
+        return False
+    host = urlparse(url).hostname or ""
+    port = urlparse(url).port or (443 if require_https else 80)
+    try:
+        records = await asyncio.to_thread(
+            socket.getaddrinfo, host, port, type=socket.SOCK_STREAM)
+    except OSError:
+        return False
+    addresses = {record[4][0] for record in records if record[4]}
+    return bool(addresses) and all(ipaddress.ip_address(address).is_global for address in addresses)
+
+
+@dataclass
+class _Session:
+    digest: str
+    expires_at: float
+
+
+class SessionManager:
+    def __init__(self, ttl_seconds: int = 21600, fixed_token: str = ""):
+        self.ttl_seconds = max(300, int(ttl_seconds))
+        self.fixed_token = fixed_token.strip()
+        self._sessions: dict[str, _Session] = {}
+
+    @staticmethod
+    def _digest(token: str) -> str:
+        return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+    def issue(self) -> tuple[str, float]:
+        token = self.fixed_token or secrets.token_urlsafe(32)
+        expires_at = time.time() + self.ttl_seconds
+        self._sessions[self._digest(token)] = _Session(
+            self._digest(token), expires_at)
+        return token, expires_at
+
+    def valid(self, token: str) -> bool:
+        token = str(token or "").strip()
+        if not token:
+            return False
+        if self.fixed_token and hmac.compare_digest(token, self.fixed_token):
+            return True
+        digest = self._digest(token)
+        session = self._sessions.get(digest)
+        if not session:
+            return False
+        if session.expires_at <= time.time():
+            self._sessions.pop(digest, None)
+            return False
+        return True
+
+    def cleanup(self):
+        now = time.time()
+        for digest, session in list(self._sessions.items()):
+            if session.expires_at <= now:
+                self._sessions.pop(digest, None)
+
+
+def request_token(request, body: dict | None = None) -> str:
+    auth = request.headers.get("authorization", "")
+    if auth.lower().startswith("bearer "):
+        return auth[7:].strip()
+    return (
+        request.query.get("t")
+        or request.headers.get("x-sidecar-token")
+        or str((body or {}).get("token") or "")
+    ).strip()

--- a/services/toastflix_sidecar/sync.py
+++ b/services/toastflix_sidecar/sync.py
@@ -1,0 +1,403 @@
+import asyncio
+import math
+import os
+import re
+import shutil
+import statistics
+import tempfile
+from array import array
+from pathlib import Path
+from urllib.parse import urljoin, urlparse
+
+import aiohttp
+
+from .audio import AudioStore
+from .http_client import client_session
+from .offsets import OffsetStore
+from .security import resolves_publicly, valid_public_url
+
+
+class _MediaResponse:
+    def __init__(self, status_code: int, headers: dict, content: bytes):
+        self.status_code = status_code
+        self.headers = headers
+        self.content = content
+
+    @property
+    def text(self):
+        return self.content.decode("utf-8", errors="replace")
+
+
+class SyncEngine:
+    MAX_REDIRECTS = 5
+    MAX_PLAYLIST_BYTES = 4 * 1024 * 1024
+    MAX_MEDIA_BYTES = 32 * 1024 * 1024
+    MAX_SYNC_BYTES = 256 * 1024 * 1024
+
+    def __init__(self, audio: AudioStore, offsets: OffsetStore, proxy: str = ""):
+        self.audio = audio
+        self.offsets = offsets
+        self.proxy = proxy
+        self.sample_seconds = 20
+        self._sync_semaphore = asyncio.Semaphore(1)
+        self._downloaded_bytes = 0
+
+    def _account_bytes(self, amount: int) -> None:
+        self._downloaded_bytes += amount
+        if self._downloaded_bytes > self.MAX_SYNC_BYTES:
+            raise RuntimeError("sync download budget exceeded")
+
+    async def _get(
+        self,
+        url: str,
+        headers: dict,
+        destination: Path | None = None,
+        max_bytes: int = MAX_PLAYLIST_BYTES,
+    ):
+        current_url = url
+        try:
+            async with client_session(self.proxy, timeout=30) as (client, request_proxy):
+                for redirect_count in range(self.MAX_REDIRECTS + 1):
+                    if not valid_public_url(current_url) or not await resolves_publicly(current_url):
+                        raise ValueError("media URL is not public HTTPS")
+                    async with client.get(
+                        current_url,
+                        headers=headers,
+                        proxy=request_proxy,
+                        allow_redirects=False,
+                    ) as response:
+                        status_code = response.status
+                        response_headers = dict(response.headers)
+                        if status_code in (301, 302, 303, 307, 308):
+                            location = response_headers.get("location", "").strip()
+                            if not location:
+                                raise ValueError("media redirect has no location")
+                            next_url = urljoin(current_url, location)
+                            if not valid_public_url(next_url) or not await resolves_publicly(next_url):
+                                raise ValueError("media redirect is not public HTTPS")
+                            if redirect_count >= self.MAX_REDIRECTS:
+                                raise ValueError("too many media redirects")
+                            current_url = next_url
+                            continue
+
+                        if status_code >= 400:
+                            raise RuntimeError(f"media fetch failed: HTTP {status_code}")
+                        content_length = response_headers.get("Content-Length")
+                        if content_length:
+                            try:
+                                if int(content_length) > max_bytes:
+                                    raise ValueError("media response too large")
+                            except ValueError as exc:
+                                if str(exc) == "media response too large":
+                                    raise
+                                raise ValueError("invalid media content length") from exc
+
+                        if destination is not None:
+                            temporary = destination.with_name(f".{destination.name}.part")
+                            try:
+                                total = 0
+                                with temporary.open("wb") as output:
+                                    async for chunk in response.content.iter_chunked(64 * 1024):
+                                        total += len(chunk)
+                                        if total > max_bytes:
+                                            raise ValueError("media response too large")
+                                        output.write(chunk)
+                                self._account_bytes(total)
+                                temporary.replace(destination)
+                                content = b""
+                            finally:
+                                temporary.unlink(missing_ok=True)
+                        else:
+                            chunks = []
+                            total = 0
+                            async for chunk in response.content.iter_chunked(64 * 1024):
+                                total += len(chunk)
+                                if total > max_bytes:
+                                    raise ValueError("media response too large")
+                                chunks.append(chunk)
+                            self._account_bytes(total)
+                            content = b"".join(chunks)
+                        return _MediaResponse(status_code, response_headers, content)
+        except aiohttp.ClientError as exc:
+            raise RuntimeError(f"media fetch failed: {exc}") from exc
+        raise ValueError("too many media redirects")
+
+    @staticmethod
+    def _playlist(text: str, master_url: str):
+        entries, pending, elapsed = [], None, 0.0
+        map_url = None
+        for raw in text.splitlines():
+            line = raw.strip()
+            if line.startswith("#EXT-X-MAP:"):
+                import re
+                match = re.search(r'URI="([^"]+)"', line)
+                map_url = urljoin(master_url, match.group(1)) if match else None
+            elif line.startswith("#EXTINF:"):
+                pending = float(line.split(":", 1)[1].split(",", 1)[0])
+            elif pending is not None and line and not line.startswith("#"):
+                entries.append({"url": urljoin(master_url, line), "duration": pending, "start": elapsed})
+                elapsed += pending
+                pending = None
+        if not entries:
+            raise ValueError("empty media playlist")
+        return entries, map_url
+
+    async def _video_entries(self, url: str, headers: dict):
+        response = await self._get(url, headers)
+        return self._playlist(response.text, url)
+
+    async def _download(self, url: str, path: Path, headers: dict):
+        await self._get(url, headers, destination=path, max_bytes=self.MAX_MEDIA_BYTES)
+
+    @staticmethod
+    def _sample_entries(entries, position: float):
+        target = next((i for i, item in enumerate(entries)
+                       if item["start"] <= position < item["start"] + item["duration"]),
+                      len(entries) - 1)
+        first = max(0, target - 1)
+        local_seek = max(0.0, position - entries[first]["start"])
+        selected, available = [], 0.0
+        for item in entries[first:]:
+            selected.append(item)
+            available += item["duration"]
+            if available >= local_seek + self.sample_seconds + 5.0:
+                break
+        return selected, local_seek, sum(item["duration"] for item in entries)
+
+    async def _decode_video(self, url: str, headers: dict, position: float, directory: Path):
+        _, entries, map_url = (url, *await self._video_entries(url, headers))
+        selected, local_seek, duration = self._sample_entries(entries, position)
+        lines = ["#EXTM3U", "#EXT-X-VERSION:7", "#EXT-X-PLAYLIST-TYPE:VOD", f"#EXT-X-TARGETDURATION:{int(max(x['duration'] for x in selected)) + 1}"]
+        if map_url:
+            await self._download(map_url, directory / "video-init.mp4", headers)
+            lines.append('#EXT-X-MAP:URI="video-init.mp4"')
+        for number, item in enumerate(selected):
+            name = f"video-{number}.m4s"
+            await self._download(item["url"], directory / name, headers)
+            lines += [f"#EXTINF:{item['duration']:.6f},", name]
+        lines.append("#EXT-X-ENDLIST")
+        playlist = directory / "video.m3u8"
+        playlist.write_text("\n".join(lines) + "\n")
+        return playlist, local_seek, duration
+
+    async def _decode_reference_audio(self, url: str, headers: dict, position: float, directory: Path):
+        response = await self._get(url, headers)
+        entries, map_url = self._playlist(response.text, url)
+        selected, local_seek, duration = self._sample_entries(entries, position)
+        lines = ["#EXTM3U", "#EXT-X-VERSION:7", "#EXT-X-PLAYLIST-TYPE:VOD",
+                 f"#EXT-X-TARGETDURATION:{int(max(item['duration'] for item in selected)) + 1}"]
+        key_line = next((line.strip() for line in response.text.splitlines()
+                         if line.strip().startswith("#EXT-X-KEY:")), "")
+        if key_line and "METHOD=NONE" not in key_line.upper():
+            key_match = re.search(r'URI="([^"]+)"', key_line)
+            if key_match:
+                key_response = await self._get(urljoin(url, key_match.group(1)), headers)
+                (directory / "reference.key").write_bytes(key_response.content)
+                key_line = re.sub(r'URI="[^"]+"', 'URI="reference.key"', key_line, count=1)
+            lines.append(key_line)
+        if map_url:
+            await self._download(map_url, directory / "reference-init.mp4", headers)
+            lines.append('#EXT-X-MAP:URI="reference-init.mp4"')
+        for number, item in enumerate(selected):
+            name = f"reference-{number}.m4s"
+            await self._download(item["url"], directory / name, headers)
+            lines += [f"#EXTINF:{item['duration']:.6f},", name]
+        lines.append("#EXT-X-ENDLIST")
+        playlist = directory / "reference.m3u8"
+        playlist.write_text("\n".join(lines) + "\n")
+        return playlist, local_seek, duration
+
+    async def _media_start_time(self, url: str, headers: dict) -> float:
+        """Read the initial timestamp of Cinejoy's video-only fMP4 stream."""
+        response = await self._get(url, headers)
+        match = re.search(r'#EXT-X-MAP:URI="([^"]+)"', response.text)
+        first = next((line.strip() for line in response.text.splitlines()
+                      if line.strip() and not line.startswith("#")), "")
+        if not match or not first:
+            return 0.0
+        root = Path(tempfile.mkdtemp(prefix="cinejoy-start-"))
+        try:
+            init_path = root / "init.mp4"
+            segment_path = root / "first.m4s"
+            await asyncio.gather(
+                self._download(urljoin(url, match.group(1)), init_path, headers),
+                self._download(urljoin(url, first), segment_path, headers),
+            )
+            sample = root / "sample.mp4"
+            with sample.open("wb") as output:
+                for part in (init_path, segment_path):
+                    with part.open("rb") as source:
+                        shutil.copyfileobj(source, output, length=1024 * 1024)
+            process = await asyncio.create_subprocess_exec(
+                "ffprobe", "-v", "error", "-show_entries", "stream=start_time",
+                "-of", "default=nw=1:nk=1", str(sample),
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+            )
+            output, _ = await asyncio.wait_for(process.communicate(), timeout=20)
+            values = output.decode(errors="replace").strip().splitlines()
+            return float(values[0]) if values else 0.0
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    async def _decode_audio(self, hid: str, position: float, directory: Path):
+        metadata = self.audio.metadata(hid)
+        index = next((i for i, start in enumerate(metadata["starts"]) if start <= position < start + metadata["durs"][i]), len(metadata["segs"]) - 1)
+        first = max(0, index - 1)
+        local_seek = max(0.0, position - metadata["starts"][first])
+        selected = []
+        available = 0.0
+        for item in range(first, len(metadata["segs"])):
+            selected.append(item)
+            available += metadata["durs"][item]
+            if available >= local_seek + self.sample_seconds + 5:
+                break
+        iv = f",IV={metadata['iv']}" if metadata.get("iv") else ""
+        lines = ["#EXTM3U", "#EXT-X-VERSION:3", "#EXT-X-PLAYLIST-TYPE:VOD",
+                 f"#EXT-X-TARGETDURATION:{int(max(metadata['durs'][item] for item in selected)) + 1}",
+                 f'#EXT-X-KEY:METHOD=AES-128,URI="audio.key"{iv}']
+        (directory / "audio.key").write_bytes(self.audio.key_bytes(hid))
+        for number, item in enumerate(selected):
+            name = f"audio-{number}.ts"
+            await self._download(metadata["segs"][item], directory / name, metadata.get("headers") or {})
+            lines += [f"#EXTINF:{metadata['durs'][item]:.6f},", name]
+        lines.append("#EXT-X-ENDLIST")
+        playlist = directory / "audio.m3u8"
+        playlist.write_text("\n".join(lines) + "\n")
+        return playlist, local_seek, sum(metadata["durs"])
+
+    @staticmethod
+    async def _pcm(playlist: Path, seek: float, output: Path, audio_map: bool = True):
+        command = ["ffmpeg", "-v", "error", "-threads", "1", "-allowed_extensions", "ALL", "-protocol_whitelist", "file,crypto", "-i", str(playlist), "-ss", f"{max(0.0, seek):.3f}", "-t", "20"]
+        if audio_map:
+            command += ["-map", "0:a:0", "-vn"]
+        command += ["-ac", "1", "-ar", "8000", "-f", "s16le", "-y", str(output)]
+        process = await asyncio.create_subprocess_exec(*command, stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.PIPE)
+        _, error = await asyncio.wait_for(process.communicate(), timeout=60)
+        if process.returncode or not output.exists() or output.stat().st_size < 160000:
+            raise RuntimeError((error.decode(errors="replace") or "sample decode failed")[:300])
+
+    @staticmethod
+    def _envelope(path: Path):
+        values = array("h")
+        values.frombytes(path.read_bytes())
+        if not values:
+            return []
+        if os.sys.byteorder != "little":
+            values.byteswap()
+        step, window = 80, 160
+        prefix = [0.0]
+        for value in values:
+            prefix.append(prefix[-1] + abs(value))
+        envelope = []
+        for center in range(0, len(values), step):
+            lo, hi = max(0, center - window // 2), min(len(values), center + window // 2)
+            envelope.append((prefix[hi] - prefix[lo]) / max(1, hi - lo))
+        mean = sum(envelope) / len(envelope)
+        std = math.sqrt(sum((value - mean) ** 2 for value in envelope) / len(envelope)) or 1.0
+        return [(value - mean) / std for value in envelope]
+
+    @staticmethod
+    def _lag(reference, candidate, max_seconds=5):
+        best = (-2.0, 0)
+        for lag in range(-max_seconds * 100, max_seconds * 100 + 1):
+            if lag >= 0:
+                size = min(len(reference), len(candidate) - lag)
+                left, right = reference[:size], candidate[lag:lag + size]
+            else:
+                size = min(len(candidate), len(reference) + lag)
+                left, right = reference[-lag:-lag + size], candidate[:size]
+            if size < 500:
+                continue
+            lm, rm = sum(left) / size, sum(right) / size
+            lv = sum((value - lm) ** 2 for value in left)
+            rv = sum((value - rm) ** 2 for value in right)
+            denominator = math.sqrt(lv * rv)
+            if denominator:
+                correlation = sum((left[i] - lm) * (right[i] - rm) for i in range(size)) / denominator
+                if correlation > best[0]:
+                    best = correlation, lag
+        return best[1] / 100.0, best[0]
+
+    async def measure(self, payload: dict):
+        # Offset detection invokes several downloads and decoder processes.
+        # Serialize it so concurrent Toastflix sessions cannot multiply the
+        # CPU/RAM/network cost on a personal EasyProxy instance.
+        async with self._sync_semaphore:
+            return await self._measure(payload)
+
+    async def _measure(self, payload: dict):
+        self._downloaded_bytes = 0
+        media_key = str(payload.get("media_key") or "")
+        resolution = int(payload.get("resolution") or 0)
+        video_url = str(payload.get("video_url") or "")
+        video_headers = payload.get("video_headers") if isinstance(payload.get("video_headers"), dict) else {}
+        reference_audio_url = str(
+            payload.get("reference_audio_url") or payload.get("referenceAudio") or ""
+        ).strip()
+        audio_hid = str(payload.get("audio_hid") or "")
+        video_fp = str(payload.get("video_fingerprint") or "")
+        metadata = self.audio.metadata(audio_hid)
+        audio_fp = str(payload.get("audio_fingerprint") or metadata.get("source_fingerprint") or "")
+        cache_key = self.offsets.key(media_key, resolution, video_fp, audio_fp)
+        payload["cache_key"] = cache_key
+        lookup = await self.offsets.lookup({"cache_key": cache_key, "media_key": media_key, "resolution": resolution, "video_fingerprint": video_fp, "audio_fingerprint": audio_fp, "vpsAccess": payload.get("vpsAccess", "")})
+        if lookup:
+            result = {"status": "ok", "cached": True, **(lookup.get("details") or lookup)}
+            if reference_audio_url and not result.get("video_start_time"):
+                lookup = None
+            else:
+                result["cache_key"] = cache_key
+                return result
+        video_entries, _ = await self._video_entries(video_url, video_headers)
+        video_duration = sum(item["duration"] for item in video_entries)
+        video_start_time = 0.0
+        if reference_audio_url:
+            video_start_time = await self._media_start_time(video_url, video_headers)
+        reference_duration = video_duration
+        if reference_audio_url:
+            reference_entries, _ = await self._video_entries(reference_audio_url, video_headers)
+            reference_duration = sum(item["duration"] for item in reference_entries)
+            if abs(reference_duration - video_duration) > 1.0:
+                raise ValueError("reference audio timeline mismatch")
+        audio_duration = sum(metadata["durs"])
+        common = min(video_duration, reference_duration, audio_duration)
+        if common < 90:
+            raise ValueError("media too short")
+        positions = sorted({min(60.0, common * .1), common * .5, max(30.0, common - 90.0)})
+        measurements = []
+        with tempfile.TemporaryDirectory(prefix="sidecar-sync-") as directory:
+            root = Path(directory)
+            for index, position in enumerate(positions):
+                video_dir, audio_dir = root / f"video-{index}", root / f"audio-{index}"
+                video_dir.mkdir(), audio_dir.mkdir()
+                if reference_audio_url:
+                    reference_playlist, reference_seek, _ = await self._decode_reference_audio(
+                        reference_audio_url, video_headers, position, video_dir
+                    )
+                else:
+                    reference_playlist, reference_seek, _ = await self._decode_video(
+                        video_url, video_headers, position, video_dir
+                    )
+                audio_playlist, audio_seek, _ = await self._decode_audio(audio_hid, position, audio_dir)
+                video_pcm, audio_pcm = root / f"video-{index}.pcm", root / f"audio-{index}.pcm"
+                samples = await asyncio.gather(
+                    self._pcm(reference_playlist, reference_seek, video_pcm),
+                    self._pcm(audio_playlist, audio_seek, audio_pcm),
+                    return_exceptions=True,
+                )
+                failure = next((sample for sample in samples if isinstance(sample, BaseException)), None)
+                if failure is not None:
+                    raise RuntimeError(f"{type(failure).__name__}: {str(failure)[:260]}")
+                lag, correlation = self._lag(self._envelope(video_pcm), self._envelope(audio_pcm))
+                measurements.append({"position": position, "lag": lag, "offset": lag, "correlation": correlation})
+        valid = [item for item in measurements if item["correlation"] >= .75]
+        if len(valid) < 2:
+            result = {"status": "incompatible", "video_duration": video_duration, "audio_duration": audio_duration, "measurements": measurements}
+        else:
+            measured = statistics.median(item["offset"] for item in valid)
+            deviation = max(abs(item["offset"] - measured) for item in valid)
+            result = {"status": "ok" if deviation <= .25 else "incompatible", "offset": round(-measured + video_start_time, 3), "rate": 1.0, "confidence": min(item["correlation"] for item in valid), "deviation": deviation, "sync_mode": "constant", "video_duration": video_duration, "audio_duration": audio_duration, "measurements": measurements}
+            if reference_audio_url:
+                result["video_start_time"] = round(video_start_time, 3)
+        result["cache_key"] = cache_key
+        return result


### PR DESCRIPTION
Embedded aiohttp Toastflix sidecar integration with lazy startup, 5-minute idle shutdown, streamed and bounded downloads, redirect validation, lock cleanup, disabled persistent audio cache, and sync resource limits. Validated locally and on the VPS; no changes to toastflix-sidecar-main, no new dependencies, and no new environment variables.