### PR TITLE
Always serve dual video via EasyProxy; bump version

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,7 +35,7 @@ ALL_PROXY_ERRORS = (
 )
 
 
-APP_VERSION = "2.11.3"
+APP_VERSION = "2.11.4"
 
 
 def get_extractor_proxies(extractor_name: str) -> list:

--- a/services/proxy_dual.py
+++ b/services/proxy_dual.py
@@ -546,7 +546,7 @@ class HLSProxyDualMixin:
         return urllib.parse.urlunsplit(parts._replace(query=urllib.parse.urlencode(query)))
 
     @staticmethod
-    def _web_test_video_url(request, video_url: str, video: dict) -> str:
+    def _dual_video_proxy_url(request, video_url: str, video: dict) -> str:
         params = {
             "url": video_url,
             "redirect_stream": "true",
@@ -732,8 +732,7 @@ class HLSProxyDualMixin:
         }
         if bridge_used:
             result["sync_bridge"] = "eng"
-        if str(request.query.get("web_test") or "").lower() in {"1", "true"}:
-            result["video_url"] = self._web_test_video_url(request, video_url, video)
+        result["video_url"] = self._dual_video_proxy_url(request, video_url, video)
         result["m3u8"] = self._dual_master(result)
         return result
 

--- a/services/proxy_pages.py
+++ b/services/proxy_pages.py
@@ -425,7 +425,7 @@ class HLSProxyPagesMixin:
                 "/dual/menifest.m3u8": {
                     "get": {
                         "summary": "DUAL HLS master",
-                        "description": "Builds one HLS master containing a selected video and an extracted, synchronized audio track. The d parameter is URL-safe Base64 JSON. The endpoint is intentionally named menifest for compatibility.",
+                        "description": "Builds one HLS master containing a selected video and an extracted, synchronized audio track. The video is always served through EasyProxy's HLS proxy. The d parameter is URL-safe Base64 JSON. The endpoint is intentionally named menifest for compatibility.",
                         "parameters": [
                             {"name": "d", "in": "query", "required": True, "schema": {"type": "string"}, "description": "URL-safe Base64 JSON DualSyncRequest payload."},
                             {"name": "api_password", "in": "query", "schema": {"type": "string"}},

--- a/templates/info.html
+++ b/templates/info.html
@@ -1051,7 +1051,7 @@
                         <tr><th width="100">Method</th><th>Endpoint</th><th>Description</th></tr>
                     </thead>
                     <tbody>
-                        <tr><td><span class="endpoint-method method-get">GET</span></td><td><code>/dual/menifest.m3u8?d=&lt;BASE64_JSON&gt;</code></td><td>DUAL HLS master with synchronized video and audio</td></tr>
+                        <tr><td><span class="endpoint-method method-get">GET</span></td><td><code>/dual/menifest.m3u8?d=&lt;BASE64_JSON&gt;</code></td><td>DUAL HLS master with synchronized audio; video always served through EasyProxy</td></tr>
                         <tr><td><span class="endpoint-method method-get">GET</span></td><td><code>/dual/manifest.m3u8?d=&lt;BASE64_JSON&gt;</code></td><td>Correctly spelled alias for the DUAL manifest</td></tr>
                         <tr><td><span class="endpoint-method method-post">POST</span></td><td><code>/dual/sync/links</code></td><td>JSON test: resolves video/audio and returns the synchronization result</td></tr>
                         <tr><td><span class="endpoint-method method-post">POST</span></td><td><code>/dual/cache/status</code></td><td>Checks only the shared DUAL offset cache</td></tr>

--- a/templates/url_generator.html
+++ b/templates/url_generator.html
@@ -1399,11 +1399,7 @@
 
         document.getElementById('playDualResult').addEventListener('click', () => {
             const url = document.getElementById('dualResult').value.trim();
-            if (url) {
-                const testUrl = new URL(url, window.location.href);
-                testUrl.searchParams.set('web_test', '1');
-                openPlayerModal(testUrl.toString());
-            }
+            if (url) openPlayerModal(url);
         });
 
         document.getElementById('showDualPayload').addEventListener('click', (event) => {


### PR DESCRIPTION
Bump app version to 2.11.4 and change dual HLS behavior so the video is always served through EasyProxy. Rename _web_test_video_url to _dual_video_proxy_url and always include video_url in the dual response (remove conditional web_test gating). Update UI to stop appending web_test when launching the player, and update API/docs templates to reflect that video is always proxied.