### PR TITLE
Bump version and shorten sync sample window

### DIFF
--- a/config.py
+++ b/config.py
@@ -36,7 +36,7 @@ ALL_PROXY_ERRORS = (
 )
 
 
-APP_VERSION = "2.11.5"
+APP_VERSION = "2.11.6"
 
 _MEMORY_PROFILE_FRAMES = 15
 _memory_profile_baseline = None

--- a/services/dual/sync.py
+++ b/services/dual/sync.py
@@ -44,7 +44,7 @@ class SyncEngine:
         self.audio = audio
         self.offsets = offsets
         self.routing = RoutingOptions(forced_proxy=proxy.strip() or None)
-        self.sample_seconds = 20
+        self.sample_seconds = 5
         self._sync_semaphore = asyncio.Semaphore(1)
         self._media_download_semaphore = asyncio.Semaphore(6)
         self._downloaded_bytes = 0


### PR DESCRIPTION
Update app version to 2.11.6 and reduce SyncEngine.sample_seconds from 20 to 5 to improve sampling responsiveness. Changes made in config.py (APP_VERSION) and services/dual/sync.py (sample_seconds).