### PR TITLE
Centralize direct-connection checks in config

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,7 +35,7 @@ ALL_PROXY_ERRORS = (
 )
 
 
-APP_VERSION = "2.11.15"
+APP_VERSION = "2.11.16"
 
 _MEMORY_PROFILE_FRAMES = 15
 _memory_profile_baseline = None
@@ -343,6 +343,12 @@ def get_transport_route_proxy(url: str, transport_routes: list) -> str | None:
 def _get_dynamic_warp_enabled() -> bool:
     return _cfg_get("enable_warp", False)
 
+def is_direct_connection_allowed(bypass_warp: bool | None = None) -> bool:
+    """Allow direct only when WARP is explicitly bypassed or disabled in admin."""
+    if bypass_warp is None:
+        bypass_warp = BYPASS_WARP_CONTEXT.get()
+    return bool(bypass_warp or not _get_dynamic_warp_enabled())
+
 def _get_dynamic_warp_exclude_domains() -> list:
     defaults = _cfg_get("warp_exclude_domains", [])
     custom = _cfg_get("warp_exclude_domains_custom", [])
@@ -480,7 +486,7 @@ def should_allow_direct_fallback(
     proxies: list | None,
     bypass_warp: bool | None = None,
 ) -> bool:
-    """Allow direct only when explicitly bypassing WARP and no proxy exists."""
+    """Allow direct when WARP is bypassed/disabled and no proxy exists."""
     if getattr(proxies, "strict", False):
         return False
     active = [proxy for proxy in proxies or [] if proxy]
@@ -488,9 +494,8 @@ def should_allow_direct_fallback(
         return False
     if bypass_warp is None:
         bypass_warp = BYPASS_WARP_CONTEXT.get()
-    # Direct is an explicit opt-in only. A disabled WARP route with no explicit
-    # bypass still fails closed instead of leaking the VPS public IP.
-    return bool(bypass_warp)
+    # Direct is allowed when WARP is explicitly bypassed or disabled in admin.
+    return is_direct_connection_allowed(bypass_warp)
 
 
 async def get_preferred_proxy_for_url(

--- a/extractors/base.py
+++ b/extractors/base.py
@@ -37,7 +37,7 @@ class BaseExtractor:
         proxy = await get_preferred_proxy_for_url(url, self.extractor_name, self.proxies or _cfg.GLOBAL_PROXIES)
 
         async with self._session_lock:
-            if proxy is None and not _cfg.BYPASS_WARP_CONTEXT.get():
+            if proxy is None and not _cfg.is_direct_connection_allowed():
                 raise ClientConnectionError(
                     "No proxy route available; direct fallback disabled"
                 )

--- a/extractors/dlstreams.py
+++ b/extractors/dlstreams.py
@@ -201,7 +201,7 @@ class DLStreamsExtractor:
         # Determine the correct proxy for the current state
         target_url = url or self.stream_origin or self.entry_origin
         proxy_url = await get_preferred_proxy_for_url(target_url, "dlstreams", self.proxies, self.bypass_warp_active)
-        if proxy_url is None and not self.bypass_warp_active and not _cfg.BYPASS_WARP_CONTEXT.get():
+        if proxy_url is None and not _cfg.is_direct_connection_allowed(self.bypass_warp_active):
             raise aiohttp.ClientConnectionError(
                 "DLStreams: direct fallback disabled; no proxy route available"
             )

--- a/extractors/doodstream.py
+++ b/extractors/doodstream.py
@@ -7,7 +7,8 @@ import time
 from urllib.parse import urljoin, urlparse
 
 from curl_cffi.requests import AsyncSession
-from config import BYPASS_WARP_CONTEXT, get_preferred_proxy_for_url
+from config import get_preferred_proxy_for_url
+import config as _cfg
 from utils.cookie_cache import CookieCache
 
 logger = logging.getLogger(__name__)
@@ -121,7 +122,7 @@ class DoodStreamExtractor:
         bypass_warp: bool = False,
     ) -> dict | None:
         normalized_proxy = self._normalize_proxy_url(proxy_url) if proxy_url else None
-        if normalized_proxy is None and not (bypass_warp or BYPASS_WARP_CONTEXT.get()):
+        if normalized_proxy is None and not _cfg.is_direct_connection_allowed(bypass_warp):
             raise ExtractorError(
                 "DoodStream: direct fallback disabled; no proxy route available"
             )

--- a/extractors/embedst.py
+++ b/extractors/embedst.py
@@ -5,7 +5,8 @@ import os
 import shutil
 from typing import Any
 
-from config import BYPASS_WARP_CONTEXT, get_preferred_proxy_for_url
+from config import get_preferred_proxy_for_url
+import config as _cfg
 from extractors.base import BaseExtractor, ExtractorError
 logger = logging.getLogger(__name__)
 
@@ -59,7 +60,7 @@ class EmbedStExtractor(BaseExtractor):
         proxy = await get_preferred_proxy_for_url(
             url, "embedst", self.proxies, bypass_warp
         )
-        if proxy is None and not (bypass_warp or BYPASS_WARP_CONTEXT.get()):
+        if proxy is None and not _cfg.is_direct_connection_allowed(bypass_warp):
             raise ExtractorError(
                 "EmbedSt: direct fallback disabled; no proxy route available"
             )
@@ -182,7 +183,7 @@ class EmbedStExtractor(BaseExtractor):
         proxy = await get_preferred_proxy_for_url(
             url, "embedst", self.proxies, self.bypass_warp_active
         )
-        if proxy is None and not (self.bypass_warp_active or BYPASS_WARP_CONTEXT.get()):
+        if proxy is None and not _cfg.is_direct_connection_allowed(self.bypass_warp_active):
             raise ExtractorError(
                 "EmbedSt: direct fallback disabled; no proxy route available"
             )

--- a/extractors/freeshot.py
+++ b/extractors/freeshot.py
@@ -35,7 +35,7 @@ class FreeshotExtractor:
 
     async def _get_session(self, url: str = None):
         proxy = await get_preferred_proxy_for_url(url, "freeshot", self.proxies)
-        if proxy is None and not _cfg.BYPASS_WARP_CONTEXT.get():
+        if proxy is None and not _cfg.is_direct_connection_allowed():
             raise aiohttp.ClientConnectionError(
                 "Freeshot: direct fallback disabled; no proxy route available"
             )

--- a/extractors/mixdrop.py
+++ b/extractors/mixdrop.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse, urljoin
 from curl_cffi.requests import AsyncSession
 from bs4 import BeautifulSoup
 
-from config import BYPASS_WARP_CONTEXT, get_preferred_proxy_for_url
+from config import get_preferred_proxy_for_url
 import config as _cfg
 from utils.cookie_cache import CookieCache
 
@@ -80,7 +80,7 @@ class MixdropExtractor:
 
         logger.info(f"🔍 [Cache Miss] Extracting new link for: {normalized_url}")
         proxy = await get_preferred_proxy_for_url(normalized_url, "mixdrop", self.proxies, self.bypass_warp_active)
-        if proxy is None and not self.bypass_warp_active and not BYPASS_WARP_CONTEXT.get():
+        if proxy is None and not _cfg.is_direct_connection_allowed(self.bypass_warp_active):
             raise ExtractorError(
                 "Mixdrop: direct fallback disabled; no proxy route available"
             )
@@ -108,7 +108,7 @@ class MixdropExtractor:
                 try:
                     m_headers = self._step_headers(ua, current_url)
                     pref_p = await get_preferred_proxy_for_url(current_url, "mixdrop", self.proxies, self.bypass_warp_active)
-                    if pref_p is None and not self.bypass_warp_active and not BYPASS_WARP_CONTEXT.get():
+                    if pref_p is None and not _cfg.is_direct_connection_allowed(self.bypass_warp_active):
                         raise ExtractorError(
                             "Mixdrop: direct fallback disabled; no proxy route available"
                         )

--- a/extractors/sportsonline.py
+++ b/extractors/sportsonline.py
@@ -156,7 +156,7 @@ class SportsonlineExtractor:
 
     async def _get_session(self, url: str = None, force_direct: bool = False):
         if force_direct:
-            if not _cfg.BYPASS_WARP_CONTEXT.get():
+            if not _cfg.is_direct_connection_allowed():
                 raise aiohttp.ClientConnectionError(
                     "Sportsonline: implicit direct fallback disabled"
                 )
@@ -164,7 +164,7 @@ class SportsonlineExtractor:
         else:
             proxy = await get_preferred_proxy_for_url(url, "sportsonline", self.proxies)
 
-        if proxy is None and not _cfg.BYPASS_WARP_CONTEXT.get():
+        if proxy is None and not _cfg.is_direct_connection_allowed():
             raise aiohttp.ClientConnectionError(
                 "Sportsonline: direct fallback disabled; no proxy route available"
             )

--- a/extractors/vavoo.py
+++ b/extractors/vavoo.py
@@ -76,7 +76,7 @@ class VavooExtractor:
                     BYPASS_WARP_CONTEXT.get(),
                 )
 
-            if self._proxy is None and not BYPASS_WARP_CONTEXT.get():
+            if self._proxy is None and not _cfg.is_direct_connection_allowed():
                 raise ClientConnectionError(
                     "Vavoo: direct fallback disabled; no proxy route available"
                 )

--- a/extractors/vidfast.py
+++ b/extractors/vidfast.py
@@ -15,6 +15,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from config import get_preferred_proxy_for_url
+import config as _cfg
 from extractors.base import ExtractorError
 
 logger = logging.getLogger(__name__)
@@ -71,7 +72,7 @@ class VidFastExtractor:
                 url, self.extractor_name, self.proxies, bypass_warp
             )
 
-        if proxy is None and not (direct_requested or bypass_warp):
+        if proxy is None and not (direct_requested or _cfg.is_direct_connection_allowed(bypass_warp)):
             raise ExtractorError(
                 "VidFast: direct fallback disabled; no proxy route available"
             )

--- a/extractors/vidlink.py
+++ b/extractors/vidlink.py
@@ -9,7 +9,8 @@ from urllib.parse import parse_qsl, urlencode, urlparse
 from curl_cffi.requests import AsyncSession
 from nacl.secret import SecretBox
 
-from config import BYPASS_WARP_CONTEXT, get_preferred_proxy_for_url
+from config import get_preferred_proxy_for_url
+import config as _cfg
 from extractors.base import ExtractorError
 
 logger = logging.getLogger(__name__)
@@ -148,7 +149,7 @@ class VidLinkExtractor:
         proxy = await get_preferred_proxy_for_url(
             api_url, self.extractor_name, self.proxies, bypass_warp
         )
-        if proxy is None and not (bypass_warp or BYPASS_WARP_CONTEXT.get()):
+        if proxy is None and not _cfg.is_direct_connection_allowed(bypass_warp):
             raise ExtractorError(
                 "VidLink: direct fallback disabled; no proxy route available"
             )

--- a/extractors/vixsrc.py
+++ b/extractors/vixsrc.py
@@ -399,7 +399,7 @@ class VixSrcExtractor:
         proxy = forced_proxy or self.session_proxy
         if proxy:
             proxy = self._normalize_proxy_url(proxy)
-        allow_direct = bool(self.bypass_warp_active or _cfg.BYPASS_WARP_CONTEXT.get())
+        allow_direct = _cfg.is_direct_connection_allowed(self.bypass_warp_active)
         solution = await solve_cloudflare(
             url,
             proxy_url=get_solver_proxy_url(proxy),
@@ -426,7 +426,7 @@ class VixSrcExtractor:
         proxies_to_try = await self._proxy_candidates(url, forced_proxy)
         if not proxies_to_try and forced_proxy:
             raise ExtractorError("No alive VixSrc forced proxy available")
-        if not proxies_to_try and not self.bypass_warp_active and not _cfg.BYPASS_WARP_CONTEXT.get():
+        if not proxies_to_try and not _cfg.is_direct_connection_allowed(self.bypass_warp_active):
             raise ExtractorError("No alive VixSrc proxy route available; direct fallback disabled")
         preferred_proxy = proxies_to_try[0] if proxies_to_try else None
         logger.info(
@@ -604,7 +604,7 @@ class VixSrcExtractor:
             proxy = self._get_random_proxy()
         if proxy:
             proxy = self._normalize_proxy_url(proxy)
-        if proxy is None and not self.bypass_warp_active and not _cfg.BYPASS_WARP_CONTEXT.get():
+        if proxy is None and not _cfg.is_direct_connection_allowed(self.bypass_warp_active):
             raise aiohttp.ClientConnectionError(
                 "VixSrc: direct fallback disabled; no proxy route available"
             )

--- a/services/proxy_core.py
+++ b/services/proxy_core.py
@@ -596,7 +596,7 @@ class HLSProxyCoreMixin:
                     await p_sess.close()
 
         proxy = forced_proxy or get_proxy_for_url(url, bypass_warp=bypass_warp)
-        if not proxy and not bypass_warp:
+        if not proxy and not _config.is_direct_connection_allowed(bypass_warp):
             raise aiohttp.ClientConnectionError(
                 "No proxy route available; direct fallback disabled"
             )


### PR DESCRIPTION
Add config.is_direct_connection_allowed() and use it across extractors and proxy core to centralize direct-fallback logic (allows direct only when WARP is bypassed or disabled). Replace scattered BYPASS_WARP_CONTEXT checks with the new helper, update imports where needed, and bump APP_VERSION to 2.11.16. This unifies behavior to avoid accidental public-IP leaks when WARP is disabled and clarifies direct-connection policy across multiple extractors and services.