### PR TITLE
Bump version; fix FlareSolverr proxy handling

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,7 +35,7 @@ ALL_PROXY_ERRORS = (
 )
 
 
-APP_VERSION = "2.11.16"
+APP_VERSION = "2.11.17"
 
 _MEMORY_PROFILE_FRAMES = 15
 _memory_profile_baseline = None

--- a/extractors/vixsrc.py
+++ b/extractors/vixsrc.py
@@ -489,6 +489,7 @@ class VixSrcExtractor:
                 return False, proxy, None, exc, None, False
 
         challenge_proxy = None
+        challenge_detected = False
         for imp in impersonations:
             if asyncio.current_task().cancelled():
                 logger.info("Extraction cancelled, skipping remaining impersonations for %s", url)
@@ -506,22 +507,29 @@ class VixSrcExtractor:
                     self.last_used_direct = proxy is None
                     logger.info("curl_cffi success via %s for %s (imp=%s)", proxy or "direct", url, imp)
                     return response
-                if is_challenge and challenge_proxy is None:
-                    challenge_proxy = proxy_value
+                if is_challenge:
+                    challenge_detected = True
+                    if challenge_proxy is None and proxy_value is not None:
+                        challenge_proxy = proxy_value
                 if isinstance(status, int):
                     last_status = status
                 if exc:
                     last_error = exc
 
-        if challenge_proxy is not None:
+        if challenge_detected:
             try:
                 if last_status == 403:
                     self._invalidate_cached_solver_state(url)
                     final_headers = self._fresh_headers(**(headers or {}))
+                solver_proxy = forced_proxy or challenge_proxy or preferred_proxy
+                if solver_proxy is None:
+                    # Prevent a stale proxy from a previous request from being
+                    # reused when this request explicitly selected direct.
+                    self.session_proxy = None
                 return await self._flaresolverr_response(
                     url,
                     headers=final_headers,
-                    forced_proxy=forced_proxy or challenge_proxy or preferred_proxy,
+                    forced_proxy=solver_proxy,
                 )
             except Exception as solver_exc:
                 logger.warning("FlareSolverr challenge solve failed for %s: %s", url, solver_exc)


### PR DESCRIPTION
Bump APP_VERSION to 2.11.17. In extractors/vixsrc.py introduce a challenge_detected flag and only record challenge_proxy when a proxy value is present. Use solver_proxy = forced_proxy or challenge_proxy or preferred_proxy when calling _flaresolverr_response and clear session_proxy if solver_proxy is None to avoid reusing a stale proxy when a direct request was intended. Keeps existing status/error handling and logs solver failures.