### PR TITLE
Fix MPD/HLS timing & proxy session handling

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,7 +35,7 @@ ALL_PROXY_ERRORS = (
 )
 
 
-APP_VERSION = "2.11.23"
+APP_VERSION = "2.11.24"
 
 _MEMORY_PROFILE_FRAMES = 15
 _memory_profile_baseline = None

--- a/extractors/registry_resolver.py
+++ b/extractors/registry_resolver.py
@@ -75,7 +75,7 @@ def _build_proxy_list(primary_proxy: str | None = None, extractor_name: str | No
             proxies.append(proxy)
 
     if (
-        _config.ENABLE_WARP
+        _config._get_dynamic_warp_enabled()
         and not BYPASS_WARP_CONTEXT.get()
         and not _config._is_warp_excluded(extractor_name or "")
         and not any(_config.is_warp_proxy_url(proxy) for proxy in proxies)

--- a/services/proxy_manifest.py
+++ b/services/proxy_manifest.py
@@ -321,7 +321,7 @@ class HLSProxyManifestHandlerMixin:
                             captured_manifest = await resp.text()
                             stream_url = str(resp.url)
                     finally:
-                        if mpd_proxy_used:
+                        if mpd_session and not mpd_session.closed:
                             await mpd_session.close()
 
                 # Encode DASH routing state into base64 token (stateless, no server-side session)
@@ -572,6 +572,12 @@ class HLSProxyManifestHandlerMixin:
                                 mpd_proxy,
                                 extractor_key=request.query.get("extractor_key"),
                             )
+                        if mpd_proxy:
+                            # A pooled SOCKS connector can remain open while
+                            # WireProxy's tunnel is stale. Reusing it for the
+                            # retry only repeats the same timeout; force the
+                            # next attempt to create a fresh route session.
+                            await self._invalidate_proxy_session(mpd_proxy)
                         # Clear sticky context if it's a proxy error
                         if is_proxy and SELECTED_PROXY_CONTEXT.get() and not STRICT_PROXY_CONTEXT.get():
                             logger.info("   [MPD] Clearing sticky proxy context due to ProxyError")
@@ -588,7 +594,7 @@ class HLSProxyManifestHandlerMixin:
                             return web.Response(text=f"Unexpected error fetching MPD: {e}", status=500)
                         await asyncio.sleep(1)
                     finally:
-                        if mpd_session and mpd_proxy:
+                        if mpd_session and not mpd_session.closed:
                             await mpd_session.close()
 
                 if manifest_content is None:

--- a/services/proxy_streaming.py
+++ b/services/proxy_streaming.py
@@ -1786,7 +1786,6 @@ class HLSProxyStreamingMixin:
                     finally:
                         if (
                             retry_session
-                            and retry_proxy
                             and not retry_session.closed
                         ):
                             await retry_session.close()
@@ -1802,7 +1801,7 @@ class HLSProxyStreamingMixin:
                             "Recovered ClearKey segment request through a fresh WARP session"
                         )
             finally:
-                if segment_session and segment_proxy and not segment_session.closed:
+                if segment_session and not segment_session.closed:
                     await segment_session.close()
 
             if init_content is None and init_url:

--- a/utils/mpd_converter.py
+++ b/utils/mpd_converter.py
@@ -40,6 +40,24 @@ class MPDToHLSConverter:
         # HLS clients (notably VLC) commonly advertise HEVC as hvc1,
         # while DASH manifests use the equivalent hev1 sample entry.
         return re.sub(r"^hev1(?=\.|$)", "hvc1", codec)
+
+    @staticmethod
+    def _nominal_segment_duration_units(segments):
+        """Return a stable duration for live MEDIA-SEQUENCE calculations.
+
+        Live DASH audio timelines can alternate a few milliseconds around the
+        nominal duration.  Using the first segment's duration makes the HLS
+        sequence jump when the rolling window starts on a different sample.
+        The median is stable across those small variations.
+        """
+        durations = sorted(
+            int(segment.get("d", 0))
+            for segment in segments
+            if int(segment.get("d", 0)) > 0
+        )
+        if not durations:
+            return 1
+        return max(1, durations[len(durations) // 2])
     
     def _extract_header_params(self, params: str) -> str:
         """Estrae solo i parametri necessari dalla query string originale.
@@ -464,26 +482,26 @@ class MPDToHLSConverter:
                                             timeline = r_template.find('mpd:SegmentTimeline', self.ns)
                                             if timeline is not None:
                                                 first_t = None
-                                                last_t = None
-                                                last_d = 0
+                                                current_t = None
+                                                last_end = None
                                                 for s in timeline.findall('mpd:S', self.ns):
                                                     t = s.get('t')
                                                     if t:
-                                                        temp_t = int(t)
-                                                        if first_t is None:
-                                                            first_t = temp_t
-                                                        last_t = temp_t
+                                                        current_t = int(t)
+                                                    elif current_t is None:
+                                                        current_t = 0
+                                                    if first_t is None:
+                                                        first_t = current_t
                                                     d = int(s.get('d'))
                                                     r_rep = int(s.get('r', '0'))
-                                                    if last_t is not None:
-                                                        last_t += d * r_rep
-                                                        last_d = d
+                                                    last_end = current_t + d * (r_rep + 1)
+                                                    current_t = last_end
                                                 if first_t is not None:
                                                     first_seg_time_sec = first_t / r_timescale
                                                     if first_seg_time_sec > global_first_time_sec:
                                                         global_first_time_sec = first_seg_time_sec
-                                                if last_t is not None:
-                                                    last_seg_time_sec = (last_t + last_d) / r_timescale
+                                                if last_end is not None:
+                                                    last_seg_time_sec = last_end / r_timescale
                                                     if last_seg_time_sec > global_last_time_sec:
                                                         global_last_time_sec = last_seg_time_sec
 
@@ -516,7 +534,9 @@ class MPDToHLSConverter:
                             segments_to_use = [all_segments[-1]]
 
                         first_window_seg = segments_to_use[0]
-                        sequence_duration_units = max(1, int(first_window_seg['d']))
+                        sequence_duration_units = self._nominal_segment_duration_units(
+                            all_segments
+                        )
                         sequence_time = first_window_seg['time'] - presentation_time_offset
                         sequence_preview = int(round(sequence_time / sequence_duration_units))
                         logger.debug(f"📐 [Window] rep={rep_id} edge={global_last_time_sec:.1f} first={global_first_time_sec:.1f} win={window_start_sec:.1f} segs={len(segments_to_use)} start_ts={segments_to_use[0]['time']/timescale:.1f} seq={sequence_preview}")
@@ -539,11 +559,36 @@ class MPDToHLSConverter:
                             first_seg_time_sec = first_seg['time'] / timescale
                             # DASH live manifests may reset startNumber to 1
                             # on every rolling window.  Build a stable HLS
-                            # sequence from media time and the actual segment
-                            # duration (the log shows 1.6 s, not 2 s).
-                            duration_units = max(1, int(first_seg['d']))
+                            # sequence from media time and the nominal segment
+                            # duration.  Do not use the first segment duration:
+                            # audio timelines legitimately alternate by a few
+                            # milliseconds and that made MEDIA-SEQUENCE jump.
+                            duration_units = self._nominal_segment_duration_units(
+                                all_segments
+                            )
                             media_time = first_seg['time'] - presentation_time_offset
                             media_sequence = int(round(media_time / duration_units))
+
+                            # A provider/CDN can briefly return an older rolling
+                            # window.  HLS clients treat a backwards sequence as
+                            # a playlist reset and may stop playback, so keep the
+                            # sequence monotonic for this live representation.
+                            sequence_key = f"{original_url.split('?')[0]}::{rep_id}"
+                            if not hasattr(self.__class__, '_last_sequences'):
+                                self.__class__._last_sequences = {}
+                            previous_sequence = self.__class__._last_sequences.get(
+                                sequence_key
+                            )
+                            if (
+                                previous_sequence is not None
+                                and media_sequence < previous_sequence
+                            ):
+                                media_sequence = previous_sequence
+                            self.__class__._last_sequences[sequence_key] = media_sequence
+                            while len(self.__class__._last_sequences) > 512:
+                                self.__class__._last_sequences.pop(
+                                    next(iter(self.__class__._last_sequences))
+                                )
                             
                             lines.append(f'#EXT-X-TARGETDURATION:{int(max_duration) + 1}')
                             lines.append(f'#EXT-X-MEDIA-SEQUENCE:{media_sequence}')


### PR DESCRIPTION
Bump app version and harden proxy/session handling while improving MPD→HLS timing.

Changes:
- Bump APP_VERSION to 2.11.24.
- Use dynamic warp check (_get_dynamic_warp_enabled) in registry_resolver.
- Prevent closing already-closed sessions (check .closed) in proxy_manifest and proxy_streaming.
- Invalidate pooled SOCKS proxy session before retrying MPD fetch to avoid reusing a stale connector.
- Add MPDToHLSConverter._nominal_segment_duration_units (median-based) and fix SegmentTimeline parsing to compute first/last times correctly.
- Compute MEDIA-SEQUENCE using nominal duration and enforce monotonic MEDIA-SEQUENCE per (URL,rep_id) with a capped cache (512 entries) to avoid HLS playlist resets.
- Minor cleanup: remove redundant proxy checks when closing sessions.

These changes prevent HLS sequence jumps, avoid reusing stale proxy connections that cause repeated timeouts, and make session cleanup more robust.