### PR TITLE
Retry VixSrc 403s via FlareSolverr

### DIFF
--- a/config.py
+++ b/config.py
@@ -36,7 +36,7 @@ ALL_PROXY_ERRORS = (
 )
 
 
-APP_VERSION = "2.11.25"
+APP_VERSION = "2.11.26"
 
 _MEMORY_PROFILE_FRAMES = 15
 _memory_profile_baseline = None

--- a/extractors/vixsrc.py
+++ b/extractors/vixsrc.py
@@ -521,7 +521,11 @@ class VixSrcExtractor:
                 if exc:
                     last_error = exc
 
-        if challenge_detected:
+        # A VixSrc 403 can be a bare block page without Cloudflare's usual
+        # challenge markers.  When a route exists, give FlareSolverr a chance
+        # anyway; this is especially important for the explicit DIRECT route
+        # used when WARP is disabled.
+        if challenge_detected or last_status == 403:
             try:
                 if last_status == 403:
                     self._invalidate_cached_solver_state(url)
@@ -531,6 +535,11 @@ class VixSrcExtractor:
                     # Prevent a stale proxy from a previous request from being
                     # reused when this request explicitly selected direct.
                     self.session_proxy = None
+                logger.info(
+                    "VixSrc 403/challenge fallback: starting FlareSolverr for %s via %s",
+                    url,
+                    solver_proxy or "direct",
+                )
                 return await self._flaresolverr_response(
                     url,
                     headers=final_headers,


### PR DESCRIPTION
Treat VixSrc 403 responses as a fallback trigger for FlareSolverr, even when Cloudflare challenge markers are absent. This lets the explicit direct route recover correctly and avoids reusing stale solver state. Also bumps the app version to 2.11.26.