### PR TITLE
Bump wireproxy and app version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN set -eux; \
 
 # WARP config generator and stable userspace SOCKS5 relay.
 ARG WGCF_VERSION=2.2.29
-ARG WIREPROXY_VERSION=1.1.2
+ARG WIREPROXY_VERSION=1.1.3
 RUN set -eux; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \

--- a/config.py
+++ b/config.py
@@ -46,7 +46,7 @@ _SOCKET_CHECK_EXECUTOR = ThreadPoolExecutor(
 )
 
 
-APP_VERSION = "2.11.39"
+APP_VERSION = "2.11.40"
 
 _MEMORY_PROFILE_FRAMES = 15
 _memory_profile_baseline = None


### PR DESCRIPTION
Update Dockerfile ARG WIREPROXY_VERSION from 1.1.2 to 1.1.3 and bump APP_VERSION in config.py from 2.11.39 to 2.11.40. Keeps the container using the latest WireProxy release and increments the application version.