### PR TITLE
Use warp-register and persisted WARP config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ ENV PYTHONUNBUFFERED=1
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     git \
+    jq \
+    wireguard-tools \
     tar \
     nodejs \
     node-undici \
@@ -37,18 +39,20 @@ RUN set -eux; \
     rm -rf /opt/flaresolverr/.git
 
 # WARP config generator and stable userspace SOCKS5 relay.
-ARG WGCF_VERSION=2.2.29
+# The generator is pinned so image rebuilds remain reproducible. It is used
+# only on first startup when /data/warp.conf does not exist.
+ARG WARP_GENERATOR_COMMIT=d4616f154d654d5c159c193432159240c96614bb
 ARG WIREPROXY_VERSION=1.1.3
 RUN set -eux; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
-        amd64) wgcf_arch="amd64"; wireproxy_arch="amd64" ;; \
-        arm64) wgcf_arch="arm64"; wireproxy_arch="arm64" ;; \
-        armhf) wgcf_arch="armv7"; wireproxy_arch="arm" ;; \
-        *) echo "Unsupported architecture for wgcf/wireproxy: $arch" >&2; exit 1 ;; \
+        amd64) wireproxy_arch="amd64" ;; \
+        arm64) wireproxy_arch="arm64" ;; \
+        armhf) wireproxy_arch="arm" ;; \
+        *) echo "Unsupported architecture for wireproxy: $arch" >&2; exit 1 ;; \
     esac; \
-    curl -fL "https://github.com/ViRb3/wgcf/releases/download/v${WGCF_VERSION}/wgcf_${WGCF_VERSION}_linux_${wgcf_arch}" -o /usr/local/bin/wgcf; \
-    chmod +x /usr/local/bin/wgcf; \
+    curl -fL "https://raw.githubusercontent.com/lanrat/wireguard-warp-generator/${WARP_GENERATOR_COMMIT}/scripts/warp-register.sh" -o /usr/local/bin/warp-register; \
+    chmod 700 /usr/local/bin/warp-register; \
     curl -fL "https://github.com/windtf/wireproxy/releases/download/v${WIREPROXY_VERSION}/wireproxy_linux_${wireproxy_arch}.tar.gz" -o /tmp/wireproxy.tar.gz; \
     curl -fL "https://github.com/windtf/wireproxy/releases/download/v${WIREPROXY_VERSION}/checksums.txt" -o /tmp/wireproxy.checksums; \
     checksum="$(awk -v asset="wireproxy_linux_${wireproxy_arch}.tar.gz" '$2 == asset { print $1 }' /tmp/wireproxy.checksums)"; \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,32 +5,47 @@ WARP_LICENSE_KEY="${WARP_LICENSE_KEY:-}"
 WARP_PROXY_HOST="127.0.0.1"
 WARP_PROXY_PORT="1080"
 WARP_DIR="/tmp/easyproxy-warp"
+WARP_CONFIG_FILE="${WARP_CONFIG_FILE:-/data/warp.conf}"
+WARP_GENERATOR="/usr/local/bin/warp-register"
 WARPCTL="/app/scripts/warp_userspace_ctl.sh"
+export WARP_CONFIG_FILE
 
 start_userspace_warp() {
-    echo "Starting Cloudflare WARP via wgcf + wireproxy userspace SOCKS5..."
+    echo "Starting Cloudflare WARP via saved config + wireproxy userspace SOCKS5..."
 
-    if ! command -v wgcf >/dev/null 2>&1 || \
+    if ! command -v "$WARP_GENERATOR" >/dev/null 2>&1 || \
        ! command -v wireproxy >/dev/null 2>&1; then
-        echo "wgcf or wireproxy not found. Rebuild the image."
+        echo "WARP generator or wireproxy not found. Rebuild the image."
         return 1
     fi
 
     mkdir -p "$WARP_DIR"
-    cd "$WARP_DIR" || return 1
+    mkdir -p "$(dirname "$WARP_CONFIG_FILE")"
 
-    if [ ! -f wgcf-account.toml ]; then
-        yes | wgcf register --accept-tos || return 1
+    if [ ! -s "$WARP_CONFIG_FILE" ]; then
+        echo "No saved WARP config; registering once and saving to ${WARP_CONFIG_FILE}."
+        temp_config="${WARP_CONFIG_FILE}.tmp.$$"
+        generator_args=()
+        if [ -n "$WARP_LICENSE_KEY" ]; then
+            generator_args+=(--license "$WARP_LICENSE_KEY")
+        fi
+        if ! WARP_DNS="1.1.1.1, 1.0.0.1" \
+             WARP_MTU="1280" \
+             WARP_ALLOWED_IPS="0.0.0.0/0" \
+             WARP_PERSISTENT_KEEPALIVE="25" \
+             WARP_DEVICE_TYPE="Linux" \
+             WARP_LOCALE="en_US" \
+             "$WARP_GENERATOR" "${generator_args[@]}" > "$temp_config"; then
+            rm -f "$temp_config"
+            echo "WARP registration failed; saved config was not changed." >&2
+            return 1
+        fi
+        chmod 600 "$temp_config"
+        mv -f "$temp_config" "$WARP_CONFIG_FILE"
+        echo "Saved WARP config in ${WARP_CONFIG_FILE}."
+    else
+        echo "Reusing saved WARP config: ${WARP_CONFIG_FILE}."
     fi
-
-    if [ -n "$WARP_LICENSE_KEY" ]; then
-        wgcf update --license-key "$WARP_LICENSE_KEY" || true
-    fi
-
-    rm -f wgcf-profile.conf
-    wgcf generate || return 1
-
-    install -m 600 wgcf-profile.conf /etc/wireguard/wg0.conf
 
     "$WARPCTL" start || return 1
 

--- a/scripts/warp_userspace_ctl.sh
+++ b/scripts/warp_userspace_ctl.sh
@@ -2,7 +2,7 @@
 set -eu
 
 PID_FILE="/tmp/easyproxy-warp/wireproxy.pid"
-CONFIG_FILE="/etc/wireguard/wg0.conf"
+CONFIG_FILE="${WARP_CONFIG_FILE:-/etc/wireguard/wg0.conf}"
 WIREPROXY_CONFIG="/tmp/easyproxy-warp/wireproxy.conf"
 LOG_FILE="/var/log/wireproxy.log"
 WIREPROXY_BIN="/usr/local/bin/wireproxy"
@@ -23,9 +23,8 @@ read_pid() {
 }
 
 write_wireproxy_config() {
-    # Keep WARP itself IPv4-only. The generated wgcf profile is dual-stack;
-    # retaining ::/0 makes wireproxy occasionally select an IPv6 egress even
-    # when the application requested an IPv4 route.
+    # Keep WARP itself IPv4-only. Remove any IPv6 fields even when a manually
+    # supplied/generated profile contains them.
     sed -E '/^(Address|AllowedIPs|DNS) = / {
         s/, *[^, ]*:[^, ]*//g
     }' "$CONFIG_FILE" > "$WIREPROXY_CONFIG"


### PR DESCRIPTION
Replace wgcf with a pinned warp-register generator and persist generated WARP configs to /data/warp.conf. Dockerfile: add jq and wireguard-tools, pin WARP_GENERATOR_COMMIT, download warp-register (chmod 700), and simplify wireproxy arch handling. entrypoint.sh: add WARP_CONFIG_FILE and WARP_GENERATOR, generate+save a config on first start (supports WARP_LICENSE_KEY), reuse saved config thereafter, and export the config path. scripts/warp_userspace_ctl.sh: make CONFIG_FILE configurable via WARP_CONFIG_FILE and tighten comment/IPv6-stripping logic. These changes enable reproducible image builds and runtime registration without wgcf.