### PR TITLE
Bump version and update WARP handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ Only basic environment variables need to be set in your `.env` file or container
 | `API_PASSWORD` | Password to protect the proxy API and admin panel | `ep` |
 
 ### 🛡️ Cloudflare WARP Integration
-The Docker image includes `wgcf` + `wireproxy`, providing a userspace WireGuard SOCKS5 relay.
+The Docker image includes a pinned WARP registration script and `wireproxy`, providing a
+userspace WireGuard SOCKS5 relay. The generated profile is saved in `/data/warp.conf`
+and reused on subsequent starts.
 It requires no `NET_ADMIN`, privileged mode, `/dev/net/tun`, kernel module, or
 sysctl.
 

--- a/config.py
+++ b/config.py
@@ -46,7 +46,7 @@ _SOCKET_CHECK_EXECUTOR = ThreadPoolExecutor(
 )
 
 
-APP_VERSION = "2.11.40"
+APP_VERSION = "2.11.41"
 
 _MEMORY_PROFILE_FRAMES = 15
 _memory_profile_baseline = None
@@ -193,7 +193,7 @@ LOG_LEVEL = LOG_LEVEL_MAP.get(LOG_LEVEL_STR, logging.WARNING)
 PROXY_TEST_TIMEOUT = 10
 cpu_cores = os.cpu_count() or 4
 PROXY_TEST_CONCURRENCY = 10 if cpu_cores == 1 else min(100, max(30, cpu_cores * 15))
-# Keep WARP as a normal dual-stack SOCKS route. The generated wgcf profile and
+# Keep WARP as a normal SOCKS route. The generated WireGuard profile and
 # wireproxy decide which address family is usable for each destination.
 WARP_PROXY_URL = "socks5://127.0.0.1:1080"
 # Monotonic timestamp of the last real WARP connector use. Health probes do
@@ -1145,7 +1145,7 @@ def get_system_stats():
             return "alighieri"
         if "wgx" in value:
             return "wgx"
-        if "warp" in value or "wgcf" in value:
+        if "warp" in value:
             return "warp"
         return "other"
 


### PR DESCRIPTION
Bump APP_VERSION to 2.11.41. Update README to document a pinned WARP registration script and inclusion of wireproxy; the generated profile is saved at /data/warp.conf and reused on subsequent starts. In config.py clarify comments about WARP as a normal SOCKS route/WireGuard profile and simplify get_system_stats detection to check for 'warp' only (remove 'wgcf' check). Minor wording tweaks.